### PR TITLE
fix(core): reload positive-rootpage virtual tables on reopen

### DIFF
--- a/crates/fsqlite-core/src/connection.rs
+++ b/crates/fsqlite-core/src/connection.rs
@@ -17751,34 +17751,44 @@ impl Connection {
 
             // Stock SQLite virtual tables (FTS5, rtree, etc.) have
             // rootpage=0 in sqlite_master and CREATE SQL beginning with
-            // "CREATE VIRTUAL TABLE".  Those cannot be loaded as regular
-            // B-tree tables, so skip them gracefully.  Do NOT skip entries
+            // "CREATE VIRTUAL TABLE". Those cannot be loaded as regular
+            // B-tree tables, so skip them gracefully. Do NOT skip entries
             // merely because the SQL text starts with CREATE VIRTUAL TABLE:
             // FrankenSQLite currently materializes its own virtual tables as
             // ordinary row tables with a real root page and preserves the
             // original SQL text for introspection.
-            let is_virtual = root_page_num == 0 && is_virtual_table_sql(&create_sql);
-            if is_virtual {
+            let is_virtual = is_virtual_table_sql(&create_sql);
+            if is_virtual && root_page_num == 0 {
                 tracing::warn!(
                     table = %name,
                     rootpage = root_page_num,
-                    "skipping virtual table from sqlite_master (module not loaded)"
+                    "skipping virtual table with rootpage=0 from sqlite_master"
                 );
                 continue;
             }
             let root_page_u32 =
                 crate::compat_persist::validate_sqlite_master_root_page(&name, root_page_num)?;
 
-            // Parse the CREATE TABLE to extract column info.
+            // Parse the CREATE SQL to extract column info. The sqlite_master
+            // helper understands both ordinary CREATE TABLE definitions and
+            // CREATE VIRTUAL TABLE layouts.
             let columns = crate::compat_persist::parse_columns_from_sqlite_master_sql(&create_sql);
             let num_columns = columns.len();
-            let is_autoincrement = crate::compat_persist::is_autoincrement_table_sql(&create_sql);
+            let is_autoincrement = if is_virtual {
+                false
+            } else {
+                crate::compat_persist::is_autoincrement_table_sql(&create_sql)
+            };
 
             // Track rowid alias columns (INTEGER PRIMARY KEY).
             // When a column is INTEGER PRIMARY KEY, its value is NOT stored in the
             // record payload - it IS the rowid. We need to insert the rowid at this
             // position when loading data.
-            let ipk_col_idx = columns.iter().position(|c| c.is_ipk);
+            let ipk_col_idx = if is_virtual {
+                None
+            } else {
+                columns.iter().position(|c| c.is_ipk)
+            };
             if let Some(idx) = ipk_col_idx {
                 new_alias_map.insert(name.to_ascii_lowercase(), idx);
                 if is_autoincrement {
@@ -17792,76 +17802,82 @@ impl Connection {
 
             // Parse FK definitions and UNIQUE column groups from the CREATE TABLE AST.
             let mut fk_defs = Vec::new();
-            if let Ok(Statement::CreateTable(create_stmt)) = parse_single_statement(&create_sql) {
-                if let CreateTableBody::Columns {
-                    columns: ref col_defs,
-                    ref constraints,
-                } = create_stmt.body
+            if !is_virtual {
+                if let Ok(Statement::CreateTable(create_stmt)) = parse_single_statement(&create_sql)
                 {
-                    // Column-level FK constraints.
-                    for (i, col) in col_defs.iter().enumerate() {
-                        for c in &col.constraints {
-                            if let ColumnConstraintKind::ForeignKey(ref fk_clause) = c.kind {
-                                fk_defs.push(fk_clause_to_def(&[i], fk_clause));
+                    if let CreateTableBody::Columns {
+                        columns: ref col_defs,
+                        ref constraints,
+                    } = create_stmt.body
+                    {
+                        // Column-level FK constraints.
+                        for (i, col) in col_defs.iter().enumerate() {
+                            for c in &col.constraints {
+                                if let ColumnConstraintKind::ForeignKey(ref fk_clause) = c.kind {
+                                    fk_defs.push(fk_clause_to_def(&[i], fk_clause));
+                                }
                             }
                         }
-                    }
-                    // Table-level FK constraints.
-                    for tc in constraints {
-                        if let TableConstraintKind::ForeignKey {
-                            columns: ref fk_cols,
-                            ref clause,
-                        } = tc.kind
-                        {
-                            let child_indices: Vec<usize> = fk_cols
-                                .iter()
-                                .filter_map(|fk_name| {
-                                    columns
-                                        .iter()
-                                        .position(|c| c.name.eq_ignore_ascii_case(fk_name))
-                                })
-                                .collect();
-                            if !child_indices.is_empty() {
-                                fk_defs.push(fk_clause_to_def(&child_indices, clause));
-                            }
-                        }
-                    }
-
-                    // UNIQUE column groups for in-memory constraint enforcement.
-                    if let Some(mem_table) = new_db.get_table_mut(real_root_page) {
-                        // Column-level UNIQUE/non-IPK PRIMARY KEY.
-                        for (i, col_info) in columns.iter().enumerate() {
-                            if col_info.unique && !col_info.is_ipk {
-                                mem_table.add_unique_column_group(vec![i]);
-                            }
-                        }
-                        // Table-level UNIQUE/PRIMARY KEY constraints.
+                        // Table-level FK constraints.
                         for tc in constraints {
-                            if let TableConstraintKind::Unique {
-                                columns: ref idx_cols,
-                                ..
-                            }
-                            | TableConstraintKind::PrimaryKey {
-                                columns: ref idx_cols,
-                                ..
+                            if let TableConstraintKind::ForeignKey {
+                                columns: ref fk_cols,
+                                ref clause,
                             } = tc.kind
                             {
-                                let col_indices: Vec<usize> = idx_cols
+                                let child_indices: Vec<usize> = fk_cols
                                     .iter()
-                                    .filter_map(|ic| {
-                                        if let fsqlite_ast::Expr::Column(ref col_ref, _) = ic.expr {
-                                            columns.iter().position(|c| {
-                                                c.name.eq_ignore_ascii_case(&col_ref.column)
-                                            })
-                                        } else {
-                                            None
-                                        }
+                                    .filter_map(|fk_name| {
+                                        columns
+                                            .iter()
+                                            .position(|c| c.name.eq_ignore_ascii_case(fk_name))
                                     })
                                     .collect();
-                                if !col_indices.is_empty() {
-                                    let all_ipk = col_indices.iter().all(|&i| columns[i].is_ipk);
-                                    if !all_ipk {
-                                        mem_table.add_unique_column_group(col_indices);
+                                if !child_indices.is_empty() {
+                                    fk_defs.push(fk_clause_to_def(&child_indices, clause));
+                                }
+                            }
+                        }
+
+                        // UNIQUE column groups for in-memory constraint enforcement.
+                        if let Some(mem_table) = new_db.get_table_mut(real_root_page) {
+                            // Column-level UNIQUE/non-IPK PRIMARY KEY.
+                            for (i, col_info) in columns.iter().enumerate() {
+                                if col_info.unique && !col_info.is_ipk {
+                                    mem_table.add_unique_column_group(vec![i]);
+                                }
+                            }
+                            // Table-level UNIQUE/PRIMARY KEY constraints.
+                            for tc in constraints {
+                                if let TableConstraintKind::Unique {
+                                    columns: ref idx_cols,
+                                    ..
+                                }
+                                | TableConstraintKind::PrimaryKey {
+                                    columns: ref idx_cols,
+                                    ..
+                                } = tc.kind
+                                {
+                                    let col_indices: Vec<usize> = idx_cols
+                                        .iter()
+                                        .filter_map(|ic| {
+                                            if let fsqlite_ast::Expr::Column(ref col_ref, _) =
+                                                ic.expr
+                                            {
+                                                columns.iter().position(|c| {
+                                                    c.name.eq_ignore_ascii_case(&col_ref.column)
+                                                })
+                                            } else {
+                                                None
+                                            }
+                                        })
+                                        .collect();
+                                    if !col_indices.is_empty() {
+                                        let all_ipk =
+                                            col_indices.iter().all(|&i| columns[i].is_ipk);
+                                        if !all_ipk {
+                                            mem_table.add_unique_column_group(col_indices);
+                                        }
                                     }
                                 }
                             }
@@ -17870,14 +17886,22 @@ impl Connection {
                 }
             }
 
-            let check_defs = crate::compat_persist::extract_check_constraints_from_sql(&create_sql);
+            let check_defs = if is_virtual {
+                Vec::new()
+            } else {
+                crate::compat_persist::extract_check_constraints_from_sql(&create_sql)
+            };
 
             new_schema.push(TableSchema {
                 name: name.clone(),
                 root_page: real_root_page,
                 columns,
                 indexes: Vec::new(),
-                strict: crate::compat_persist::is_strict_table_sql(&create_sql),
+                strict: if is_virtual {
+                    false
+                } else {
+                    crate::compat_persist::is_strict_table_sql(&create_sql)
+                },
                 foreign_keys: fk_defs,
                 check_constraints: check_defs,
             });
@@ -40296,6 +40320,54 @@ mod schema_loading_tests {
                 || message.contains("payload"),
             "unexpected reopen error: {message}"
         );
+    }
+
+    #[test]
+    fn test_reopen_loads_virtual_tables_with_positive_rootpage() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("vtab_positive_rootpage.db");
+        let db_str = db_path.to_string_lossy().to_string();
+
+        {
+            let conn = Connection::open(&db_str).unwrap();
+            conn.execute("CREATE VIRTUAL TABLE docs USING fts5(subject, body)")
+                .unwrap();
+            conn.execute(
+                "INSERT INTO docs(rowid, subject, body) VALUES (1, 'Hello', 'Rust world')",
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO docs(rowid, subject, body) VALUES (2, 'Other', 'Nothing here')",
+            )
+            .unwrap();
+
+            let rootpage = conn
+                .query_row("SELECT rootpage FROM sqlite_master WHERE name = 'docs'")
+                .unwrap();
+            match rootpage.values()[0] {
+                SqliteValue::Integer(value) => {
+                    assert!(
+                        value > 0,
+                        "fsqlite-native virtual tables should persist with a positive rootpage"
+                    );
+                }
+                ref other => panic!("unexpected rootpage value: {other:?}"),
+            }
+        }
+
+        let reopened = Connection::open(&db_str).unwrap();
+        let schema = reopened.schema.borrow();
+        assert!(
+            schema.iter().any(|t| t.name.eq_ignore_ascii_case("docs")),
+            "positive-rootpage virtual table should reload into schema"
+        );
+        drop(schema);
+
+        let rows = reopened
+            .query("SELECT subject FROM docs WHERE docs MATCH 'hello'")
+            .unwrap();
+        assert_eq!(rows.len(), 1, "reopened FTS table should remain queryable");
+        assert_eq!(rows[0].values()[0], SqliteValue::Text("Hello".to_owned()));
     }
 
     #[test]


### PR DESCRIPTION
## A) Executive summary
- FrankenSQLite currently distinguishes legacy SQLite virtual tables (`rootpage=0`) from ordinary tables, but it still treats **positive-rootpage** `CREATE VIRTUAL TABLE` entries as if they were ordinary `CREATE TABLE` rows during schema reload.
- That behavior is incorrect for FrankenSQLite-native virtual tables that already have a safe positive root page and should remain queryable after reopen.
- This patch keeps skipping legacy `rootpage=0` virtual tables, but reloads positive-rootpage virtual tables as **virtual-table entries**, not ordinary row tables.
- The core change suppresses ordinary-table-only assumptions during reload (IPK aliasing, AUTOINCREMENT, FK extraction, UNIQUE groups, CHECK extraction, STRICT-table derivation).
- This is a follow-up to the previously closed `rootpage=0` issue in #15, not a replacement for full planner/VDBE virtual-table routing for legacy SQLite databases.
- Downstream, this fixes a real reopen regression for agent-kernel’s file-backed FTS path: positive-rootpage virtual tables remain queryable after reopen instead of drifting into an invalid ordinary-table interpretation.
- Migration risk is low: the patch narrows behavior to `CREATE VIRTUAL TABLE` rows only and preserves the existing skip behavior for legacy `rootpage=0` entries.

## B) Current state and pain profile
- Current behavior:
  - During schema reload from `sqlite_master`, FrankenSQLite identifies virtual tables only when both conditions hold: the SQL is `CREATE VIRTUAL TABLE ...` **and** `rootpage == 0`.
  - Legacy SQLite virtual tables therefore get skipped, which avoids driving them through the ordinary B-tree open path.
  - But positive-rootpage virtual tables fall through the ordinary table path and inherit `CREATE TABLE`-style parsing and constraint/index assumptions.
- Limitation(s):
  - Positive-rootpage virtual tables are not reloaded with virtual-table semantics.
  - Reload logic applies ordinary-table-only behaviors to virtual-table SQL.
  - Reopen safety for FrankenSQLite-native virtual tables is therefore weaker than it should be.
- Workaround(s) in the wild:
  - Downstream consumers rebuild or refresh database state to restore search/queryability after reopen.
  - Operators rely on migrations/bootstrap flows instead of trusting virtual-table reload semantics directly.
- Why workaround is insufficient:
  - It turns a reopen-time correctness bug into an operational ritual.
  - It hides the real schema-reload contract: positive-rootpage virtual tables should not need external rebuilding to stay usable.

## C) Problem statement
- In-scope problem:
  - Treat positive-rootpage `CREATE VIRTUAL TABLE` entries correctly during schema reload so they remain virtual-table-shaped metadata, not ordinary row-table metadata.
- Out-of-scope / non-goals:
  - Full SQLite-compatible planner/VDBE routing for legacy `rootpage=0` virtual tables.
  - Implementing `VOpen`/`VFilter`/`VNext` parity for SQLite-created virtual tables.
  - General virtual-table feature expansion beyond reload correctness.
- Success criteria:
  - Legacy `rootpage=0` virtual tables are still skipped.
  - Positive-rootpage virtual tables are reloaded instead of skipped.
  - Positive-rootpage virtual tables do not inherit ordinary-table-only schema assumptions during reload.
  - Reopened FrankenSQLite-native virtual tables remain queryable in downstream file-backed workflows.

## D) Design constraints
- Compatibility constraints:
  - Must preserve existing safety behavior for legacy SQLite virtual tables with `rootpage=0`.
  - Must not reinterpret ordinary `CREATE TABLE` entries.
  - Must not claim full planner/VDBE virtual-table parity that this patch does not implement.
- Operational constraints:
  - Change should be tightly scoped to schema reload from `sqlite_master`.
  - Should cherry-pick cleanly onto current `origin/main`.
  - Must avoid depending on external bootstrap/rebuild flows.
- Security/safety constraints:
  - Do not synthesize ordinary table invariants for virtual-table SQL.
  - Avoid incorrect IPK/FK/CHECK/STRICT inference on virtual-table entries.
  - Fail-closed on legacy rootpage=0 entries by continuing to skip them.

## E) Proposed solution
- Core proposal (MVP):
  - Detect virtual-table SQL independently from rootpage.
  - Skip only the legacy case: `is_virtual && rootpage == 0`.
  - For `is_virtual && rootpage > 0`, reload the entry into in-memory schema while disabling ordinary-table-only derivations:
    - no AUTOINCREMENT inference
    - no IPK alias inference
    - no FK extraction from `CREATE TABLE` AST
    - no UNIQUE-column-group extraction
    - no CHECK extraction
    - no STRICT-table derivation
- Optional extensions:
  - Add focused reopen regression tests for positive-rootpage virtual tables.
  - Add a dedicated compatibility note in docs describing the distinction between legacy SQLite virtual tables and FrankenSQLite-native positive-rootpage virtual tables.
  - Later planner/VDBE work to route legacy `rootpage=0` entries through proper virtual-table execution instead of skip-only behavior.

## F) API proposal (typed)
Provide concise TypeScript-style snippets.

```ts
// proposed behavioral contract for sqlite_master reload
interface SqliteMasterEntry {
  name: string;
  rootpage: number;
  sql: string;
}

interface ReloadDecision {
  skip: boolean;
  treatAsVirtual: boolean;
}

function classifyVirtualTableReload(entry: SqliteMasterEntry): ReloadDecision {
  const isVirtual = entry.sql.startsWith("CREATE VIRTUAL TABLE");

  if (isVirtual && entry.rootpage === 0) {
    return { skip: true, treatAsVirtual: true };
  }

  if (isVirtual && entry.rootpage > 0) {
    return { skip: false, treatAsVirtual: true };
  }

  return { skip: false, treatAsVirtual: false };
}
```

## G) Alternatives and trade-offs
Provide at least 3 alternatives.

| Option | Description | Pros | Cons | Why not chosen |
|---|---|---|---|---|
| A | Keep current behavior | No code change | Positive-rootpage virtual tables still reload incorrectly | Leaves real reopen bug in place |
| B | Skip all `CREATE VIRTUAL TABLE` entries regardless of rootpage | Simple rule, low immediate risk | Breaks FrankenSQLite-native positive-rootpage reopenability | Too blunt; throws away safe reloadable entries |
| C | Treat all virtual tables as ordinary tables when `rootpage > 0` | Minimal special casing | Incorrect metadata derivation for virtual-table SQL; reintroduces reopen drift | This is the current problem |
| D | Preserve skip for `rootpage=0`, reload positive-rootpage entries as virtual | Narrow, additive, preserves current legacy safety while fixing reopenability | Does not solve full legacy planner/VDBE parity | Chosen because it fixes the concrete reopen regression without overclaiming |

## H) Rollout and migration plan
- Rollout phases:
  - phase 1: land scoped schema-reload fix for positive-rootpage virtual tables
  - phase 2: add or expand targeted reopen coverage around virtual-table reload semantics
- Migration strategy for existing extensions/templates:
  - No user-facing migration required.
  - Existing FrankenSQLite-native databases with positive-rootpage virtual tables benefit on next reopen.
- Backward compatibility guarantees:
  - Legacy SQLite `rootpage=0` skip behavior remains unchanged.
  - Ordinary table reload behavior remains unchanged.

## I) Validation plan
- Unit tests:
  - Add/revive coverage for positive-rootpage virtual-table reopen behavior.
  - Ensure legacy `rootpage=0` entries still skip cleanly.
- Integration tests:
  - Reopen a file-backed database containing a positive-rootpage virtual table and verify it remains queryable.
  - Reconfirm downstream file-backed search/query workflows that depend on reopen semantics.
- Docs updates:
  - Optional compatibility note clarifying the split between legacy and FrankenSQLite-native virtual-table reload behavior.
- Failure mode checks:
  - No accidental ordinary-table constraint/index inference for virtual-table SQL.
  - No regression of the existing `rootpage=0` safeguard discussed in #15.

## J) Risks and mitigations
- Risk 1: Positive-rootpage virtual tables still rely on untested assumptions -> mitigation: add a dedicated reopen regression test around this exact schema-reload path.
- Risk 2: Patch is misread as full legacy virtual-table support -> mitigation: explicitly reference #15 and state that `rootpage=0` planner/VDBE parity remains out of scope.
- Risk 3: Other sqlite_master reload code paths still apply ordinary-table assumptions elsewhere -> mitigation: keep this patch narrow and use downstream reopen verification as a guardrail.

## K) Open questions for maintainers
- Q1: Do you want a dedicated regression test in this PR, or would you prefer to land the behavioral fix first and add targeted coverage in a follow-up once the local workspace dependency issue is unblocked?
- Q2: Should FrankenSQLite document the distinction between legacy SQLite virtual tables (`rootpage=0`) and FrankenSQLite-native positive-rootpage virtual tables more explicitly in the compatibility notes?
- Q3: Is there a preferred issue/ADR location for tracking the later planner/VDBE work required to give legacy `rootpage=0` virtual tables true `VOpen`/`VFilter` handling?

## L) Copy-paste issue body
Output final issue body ready to submit, with headings:
- What do you want to change?
- Why?
- How? (optional)

Use concise maintainer-facing language.

### What do you want to change?
Treat positive-rootpage `CREATE VIRTUAL TABLE` entries as virtual tables during schema reload instead of running them through the ordinary `CREATE TABLE` metadata path. Keep skipping legacy `rootpage=0` virtual tables.

Related prior work:
- #15 — direct precursor for legacy `rootpage=0` virtual-table handling
- #17 — prior sqlite_master/schema-reload compatibility defect caused by incorrect row semantics
- #20 — prior schema compatibility defect around UNIQUE/index expectations

### Why?
The current reload logic distinguishes virtual tables only when `rootpage == 0`. That preserves the legacy safeguard from #15, but it misclassifies FrankenSQLite-native positive-rootpage virtual tables as ordinary row tables on reopen.

That means reopen correctness depends on external rebuild/bootstrap flows instead of the schema reload path itself being correct. Downstream, this showed up as a real file-backed reopen regression for FTS-backed search/query flows.

### How? (optional)
- detect virtual-table SQL independently from rootpage
- skip only `CREATE VIRTUAL TABLE` entries with `rootpage == 0`
- for positive-rootpage virtual tables, reload them while disabling ordinary-table-only derivations (IPK aliasing, AUTOINCREMENT, FK/UNIQUE/CHECK extraction, STRICT inference)

## M) Optional RFC appendix
- Prior art references:
  - #15: legacy SQLite FTS5 `rootpage=0` crash on reopen / query planning mismatch
  - #17: sqlite_master row-order/schema-update correctness matters for SQLite compatibility
  - #20: schema-level implicit constraints/index expectations matter for reopen compatibility
- Implementation sketch:
  - separate `is_virtual_table_sql(create_sql)` from the `rootpage == 0` decision
  - use `rootpage == 0` only for skip-vs-reload, not for virtual-table classification itself
  - when reloading a positive-rootpage virtual table, preserve table identity but suppress ordinary table derivations
