### PR TITLE
fix(core): remove unreachable expr fallback

### DIFF
--- a/crates/fsqlite-core/src/connection.rs
+++ b/crates/fsqlite-core/src/connection.rs
@@ -26416,7 +26416,6 @@ fn expr_references_only_col_map(expr: &Expr, col_map: &[(String, String, bool)])
             .iter()
             .all(|value| expr_references_only_col_map(value, col_map)),
         Expr::Exists { .. } | Expr::Subquery(..) => false,
-        _ => false,
     }
 }
 


### PR DESCRIPTION
## Summary
- remove the unreachable wildcard arm in `expr_references_only_col_map`
- keep the match exhaustive against the current `Expr` variants
- eliminate the remaining `unreachable pattern` warning polluting downstream validation output

## Why
`Expr` is already fully matched in `fsqlite-core`, so the trailing `_ => false` arm is unreachable. Removing it makes future enum additions fail loudly and clears warning noise that was masking real regressions in downstream validation.

## Validation
- `rustfmt --edition 2024 --check crates/fsqlite-core/src/connection.rs`
- `cargo check --workspace` in downstream `agent-kernel` (compiles `fsqlite-core` as a dependency)
- `cargo clippy -p ak-core -- -D warnings`

## Notes
Direct `frankensqlite` workspace cargo commands are currently blocked in this environment by a missing absolute-path dependency at `/data/projects/frankentui/crates/ftui`, so validation was performed on the downstream build surface that consumes this crate.
