### PR TITLE
fsqlite-vfs: add FreeBSD l_sysid field to flock initializers

### DIFF
--- a/crates/fsqlite-vfs/src/unix.rs
+++ b/crates/fsqlite-vfs/src/unix.rs
@@ -254,6 +254,12 @@ fn posix_lock(file: &impl AsFd, lock_type: impl Into<i32>, start: u64, len: u64)
         l_start: start as libc::off_t,
         l_len: len as libc::off_t,
         l_pid: 0,
+        // FreeBSD's struct flock has an additional l_sysid field for
+        // clustered/network file systems. l_sysid: 0 means "no specific
+        // system" — the documented default for non-clustered local locks.
+        // Linux/macOS flock structs do not have this field.
+        #[cfg(target_os = "freebsd")]
+        l_sysid: 0,
     };
 
     loop {
@@ -345,6 +351,10 @@ fn posix_getlk(
         l_start: start as libc::off_t,
         l_len: len as libc::off_t,
         l_pid: 0,
+        // FreeBSD's struct flock has an additional l_sysid field. See the
+        // matching comment at the F_SETLK callsite above.
+        #[cfg(target_os = "freebsd")]
+        l_sysid: 0,
     };
 
     nix::fcntl::fcntl(


### PR DESCRIPTION

### Problem

fsqlite-vfs 0.1.3 fails to compile on FreeBSD 15 with:

```
error[E0063]: missing field `l_sysid` in initializer of `libc::flock`
   --> src/unix.rs:250:NN
   --> src/unix.rs:292:NN
```

FreeBSD's `struct flock` has an extra field — `l_sysid` (system ID for clustered/network file systems) — that does not exist in glibc's `flock`. The `libc` crate's `flock` binding mirrors the platform's struct, so on FreeBSD the field is part of the type and the literal initializer fails to compile without it.

Linux/macOS users won't see this because their `flock` doesn't have `l_sysid`.

### Proposed fix

Add `#[cfg(target_os = "freebsd")] l_sysid: 0,` to the two `flock` initializers:

```diff
  libc::flock {
      l_type: libc::F_WRLCK as libc::c_short,
      l_whence: libc::SEEK_SET as libc::c_short,
      l_start: 0,
      l_len: 0,
      l_pid: 0,
+     #[cfg(target_os = "freebsd")]
+     l_sysid: 0,
  };
```

`l_sysid: 0` matches the documented "no specific system" default for non-clustered local locks, which is what fsqlite-vfs needs here.

If you'd prefer, an alternative is to construct the struct via `mem::zeroed()` + field assignment, which sidesteps the per-platform field list entirely:

```rust
let mut fl: libc::flock = unsafe { std::mem::zeroed() };
fl.l_type = libc::F_WRLCK as libc::c_short;
// ...
```

Either approach works; the cfg-gated literal preserves the explicit field set, the `mem::zeroed()` form is platform-agnostic.

### Verification

I patched the registry copy in place (`~/.cargo/registry/src/.../fsqlite-vfs-0.1.3/src/unix.rs`) and rebuilt the dependent crate (`asupersync`) — compile passes. Testing is whatever testing the parent crate does; fsqlite-vfs itself has no test surface that exercises FreeBSD-specific flock behavior.

### Context

I'm using fsqlite-vfs transitively via asupersync on FreeBSD 15. Without this patch the entire asupersync build is blocked on FreeBSD.

I haven't filed a PR with these changes yet because I wanted to ask whether you'd prefer the cfg-gated-literal approach or `mem::zeroed()` first — both are tiny, just different style. Happy to send either as a PR.

