### PR TITLE
test(fsqlite): regression for issue #76 — IN+IN predicate combinations

### DIFF
--- a/crates/fsqlite/tests/in_subquery_combined_with_in_predicate_test.rs
+++ b/crates/fsqlite/tests/in_subquery_combined_with_in_predicate_test.rs
@@ -1,0 +1,107 @@
+//! Regression for issue #76: with parameterized queries, combining
+//! `id IN (SELECT issue_id FROM other WHERE col = ?)` with another
+//! `col IN (?)` predicate via AND returns empty under fsqlite, even
+//! though both predicates individually match rows.
+//!
+//! - Inlined-string variants of the same SQL work (no params).
+//! - The bug only triggers when both `IN (?)` literals are bound
+//!   parameters via `query_with_params`.
+//!
+//! Repro originally surfaced in beads_rust commit a0b45bd.
+
+use fsqlite::{Connection, SqliteValue};
+
+fn setup() -> Connection {
+    let conn = Connection::open(":memory:").unwrap();
+    conn.execute("CREATE TABLE issues (id TEXT PRIMARY KEY, issue_type TEXT NOT NULL, status TEXT NOT NULL);").unwrap();
+    conn.execute(
+        "CREATE TABLE labels (
+            issue_id TEXT NOT NULL,
+            label TEXT NOT NULL,
+            PRIMARY KEY (issue_id, label)
+         );",
+    )
+    .unwrap();
+    conn.execute("INSERT INTO issues VALUES ('a', 'task', 'open');").unwrap();
+    conn.execute("INSERT INTO issues VALUES ('b', 'feature', 'open');").unwrap();
+    conn.execute("INSERT INTO labels VALUES ('a', 'core');").unwrap();
+    conn.execute("INSERT INTO labels VALUES ('b', 'core');").unwrap();
+    conn
+}
+
+fn ids(rows: Vec<fsqlite::Row>) -> Vec<String> {
+    rows.into_iter()
+        .map(|r| r.values()[0].as_text().unwrap().to_string())
+        .collect()
+}
+
+#[test]
+fn inlined_in_subquery_alone_returns_matching_rows() {
+    let conn = setup();
+    let rows = conn
+        .query("SELECT id FROM issues WHERE id IN (SELECT issue_id FROM labels WHERE label = 'core') ORDER BY id;")
+        .unwrap();
+    assert_eq!(ids(rows), vec!["a", "b"]);
+}
+
+#[test]
+fn inlined_in_value_alone_returns_matching_row() {
+    let conn = setup();
+    let rows = conn
+        .query("SELECT id FROM issues WHERE issue_type IN ('task');")
+        .unwrap();
+    assert_eq!(ids(rows), vec!["a"]);
+}
+
+#[test]
+fn inlined_in_subquery_combined_with_in_value_returns_intersection() {
+    let conn = setup();
+    let rows = conn
+        .query("SELECT id FROM issues WHERE id IN (SELECT issue_id FROM labels WHERE label = 'core') AND issue_type IN ('task');")
+        .unwrap();
+    assert_eq!(ids(rows), vec!["a"]);
+}
+
+/// THIS IS THE BUG (issue #76): the parameterized form of the combined
+/// predicate returns empty. Same SQL shape, same data — just bound
+/// parameters instead of inlined string literals.
+#[test]
+fn parameterized_in_subquery_combined_with_in_value_returns_intersection() {
+    let conn = setup();
+    let rows = conn
+        .query_with_params(
+            "SELECT id FROM issues WHERE id IN (SELECT issue_id FROM labels WHERE label = ?) AND issue_type IN (?);",
+            &[SqliteValue::from("core"), SqliteValue::from("task")],
+        )
+        .unwrap();
+    assert_eq!(
+        ids(rows),
+        vec!["a"],
+        "BUG: parameterized IN-subquery + IN(?) returns empty; expected the intersection"
+    );
+}
+
+#[test]
+fn parameterized_in_subquery_combined_with_in_value_swapped_order() {
+    let conn = setup();
+    let rows = conn
+        .query_with_params(
+            "SELECT id FROM issues WHERE issue_type IN (?) AND id IN (SELECT issue_id FROM labels WHERE label = ?);",
+            &[SqliteValue::from("task"), SqliteValue::from("core")],
+        )
+        .unwrap();
+    assert_eq!(ids(rows), vec!["a"]);
+}
+
+#[test]
+fn parameterized_exists_subquery_combined_with_in_value_works() {
+    // EXISTS form is the workaround that already worked.
+    let conn = setup();
+    let rows = conn
+        .query_with_params(
+            "SELECT id FROM issues WHERE EXISTS (SELECT 1 FROM labels WHERE labels.issue_id = issues.id AND labels.label = ?) AND issue_type IN (?);",
+            &[SqliteValue::from("core"), SqliteValue::from("task")],
+        )
+        .unwrap();
+    assert_eq!(ids(rows), vec!["a"]);
+}


### PR DESCRIPTION
## Summary

Locks in the property that combining `id IN (SELECT col FROM other WHERE col2 = ?)` with another `col IN (?)` predicate via AND returns the correct intersection, not an empty set, when both `IN (?)` literals are bound parameters via `query_with_params`.

## Status of the bug

While investigating issue #76 against my downstream project (beads_rust), I confirmed:

- **Bug reproduces** against published `fsqlite = "0.1.2"` from crates.io
- **Bug is fixed** on upstream `main` (HEAD `e5c83f11`) — all 6 test variants pass

So the bug has already been silently fixed since the 0.1.2 release. This PR doesn't change any production code; it just adds a regression test so the property is guarded going forward.

## Test coverage

The test file (`crates/fsqlite/tests/in_subquery_combined_with_in_predicate_test.rs`) covers six variants:

1. Inlined-string `id IN (SELECT...)` alone — control
2. Inlined-string `col IN (value)` alone — control
3. Inlined-string combined predicate — should return intersection
4. **Parameterized combined predicate** — the original failure shape from #76
5. Parameterized combined predicate, swapped order — should be order-agnostic
6. Parameterized `EXISTS` form — the workaround used by downstream beads_rust

All 6 pass on upstream main; (4) and (5) fail against published 0.1.2.

## Recommended follow-up

- **Cut a 0.1.3 release** so downstream users (e.g. beads_rust) get the fix without pinning a git revision.
- After the 0.1.3 release lands, downstream projects can revert workarounds (in beads_rust's case, `append_label_membership_filters` switched to `EXISTS` uniformly to dodge the bug — that workaround can be relaxed).

## Test plan

- [x] `cargo test -p fsqlite --test in_subquery_combined_with_in_predicate_test` — 6 passed, 0 failed on upstream main
- [x] Verified bug repro against published `fsqlite = "0.1.2"` (test 4 fails)

Refs #76