### PR TITLE
Fix DB-FEC padding rows for asupersync 0.3

### DIFF
--- a/crates/fsqlite-core/src/db_fec.rs
+++ b/crates/fsqlite-core/src/db_fec.rs
@@ -740,10 +740,6 @@ pub fn attempt_page_repair(
     let k_usize = k as usize;
     let seed = derive_db_fec_repair_seed(group_meta);
     let decoder = asupersync::raptorq::decoder::InactivationDecoder::new(k_usize, page_size, seed);
-    let params = decoder.params();
-    let base_rows = params.s + params.h;
-    let constraints = asupersync::raptorq::systematic::ConstraintMatrix::build(params, seed);
-
     let mut received = decoder.constraint_symbols();
 
     for (esi, data) in &available {
@@ -767,27 +763,9 @@ pub fn attempt_page_repair(
         }
     }
 
-    // RFC 6330 decode requires K' source-domain rows; PI rows (K'−K) are
-    // zero-padded source symbols that must be represented explicitly.
-    for source_index in k_usize..params.k_prime {
-        let row = base_rows + source_index;
-        let mut columns = Vec::new();
-        let mut coefficients = Vec::new();
-        for col in 0..constraints.cols {
-            let coeff = constraints.get(row, col);
-            if !coeff.is_zero() {
-                columns.push(col);
-                coefficients.push(coeff);
-            }
-        }
-        received.push(asupersync::raptorq::decoder::ReceivedSymbol {
-            esi: u32::try_from(source_index).expect("source index fits u32"),
-            is_source: true,
-            columns,
-            coefficients,
-            data: vec![0_u8; page_size],
-        });
-    }
+    // asupersync 0.3.x synthesizes the RFC 6330 K..K' zero-padding rows
+    // internally. Supplying them as source symbols is now rejected because
+    // source ESIs are validated against the real K domain.
 
     let result = decoder
         .decode(&received)


### PR DESCRIPTION
## Summary

Fixes the DB-FEC page repair path after the move to `asupersync 0.3.1`.

`InactivationDecoder` now synthesizes RFC 6330 `K..K'` zero-padding rows internally and validates caller-provided source symbols against the real `0..K` source domain. The DB-FEC repair path was still injecting those padding rows as source symbols, which causes `SourceEsiOutOfRange`.

This removes the manual padding-row injection and lets the asupersync decoder handle the implicit rows.

Fixes #83.

## Validation

On current main before this patch:

```bash
RUSTC_BOOTSTRAP=1 cargo test -p fsqlite-core raptorq --lib
```

failed with:

```text
db_fec::tests::test_raptorq_multi_corruption_recovery ... FAILED
page 2: RaptorQ decode failed: SourceEsiOutOfRange { esi: 8, max_valid: 8 }
```

After this patch:

```bash
RUSTC_BOOTSTRAP=1 cargo test -p fsqlite-core db_fec::tests::test_raptorq_multi_corruption_recovery --lib
# 1 passed; 0 failed

RUSTC_BOOTSTRAP=1 cargo test -p fsqlite-core raptorq --lib
# 61 passed; 0 failed
```

`RUSTC_BOOTSTRAP=1` was used because current main uses `#![feature(portable_simd)]`; otherwise stable stops before these tests run.
