### PR TITLE
fix(vfs/windows): clean up advisory-lock sidecars in Vfs::delete

### DIFF
--- a/crates/fsqlite-vfs/src/windows.rs
+++ b/crates/fsqlite-vfs/src/windows.rs
@@ -70,6 +70,17 @@ fn sqlite_pending_lock_path(path: &Path) -> PathBuf {
     PathBuf::from(p)
 }
 
+// Best-effort cleanup of the three Windows VFS advisory-lock sidecar files
+// alongside `path`. Without this, every backup/temporary DB file leaks three
+// zero-byte sidecars; if cass then re-opens one of those sidecar paths as a
+// "backup root" the next round of sidecars layers on top, producing chained
+// `*-lock-pending-lock-pending-...` names.
+fn remove_windows_lock_sidecars(path: &Path) {
+    drop(fs::remove_file(sqlite_shared_lock_path(path)));
+    drop(fs::remove_file(sqlite_reserved_lock_path(path)));
+    drop(fs::remove_file(sqlite_pending_lock_path(path)));
+}
+
 fn ensure_shm_file_len(path: &Path, min_len: u64) -> Result<()> {
     let file = OpenOptions::new()
         .read(true)
@@ -488,6 +499,7 @@ impl Vfs for WindowsVfs {
         if shm_path.exists() {
             fs::remove_file(shm_path)?;
         }
+        remove_windows_lock_sidecars(&resolved);
         Ok(())
     }
 


### PR DESCRIPTION
## Problem

`WindowsOsLockFiles::open()` unconditionally creates three zero-byte advisory-lock sidecar files (`-lock-shared`, `-lock-reserved`, `-lock-pending`) next to every database file it touches. `Vfs::delete()` removes the main DB and the `-shm` sidecar but leaves the three lock sidecars behind.

In long-running workloads that create many transient DB files (e.g. `VACUUM INTO` backups), this leaks three orphan files per backup. Worse, if a caller later enumerates these orphan paths and re-opens one of them as a database, a fresh set of lock sidecars is created on top of the orphan path — producing chained `*-lock-pending-lock-pending-...` names that grow without bound.

## Real-world impact

Observed on a Windows NTFS data dir for the [`cass`](https://github.com/Dicklesworthstone/coding_agent_session_search) project: **788,972 orphan files (195 GB total)**, with chained names up to 217 characters long. The `cass` side of the bug is fixed in a sibling PR (Dicklesworthstone/coding_agent_session_search#TBD), but the root cause is the missing cleanup here.

```
agent_search.db.backup.74984.1778533470460371300.0-lock-pending
agent_search.db.backup.74984.1778533470460371300.0-lock-pending-lock-pending
agent_search.db.backup.74984.1778533470460371300.0-lock-pending-lock-pending-lock-pending
...
```

## Fix

Add a best-effort `remove_windows_lock_sidecars` helper and call it from `Vfs::delete()` so the three sidecars are removed alongside the main file. Errors are dropped because the sidecars are advisory and may already have been cleaned up.

## Validation

After applying this patch to v0.4.7 of `cass` (which pins frankensqlite ~`eba969ec`) and re-indexing 14+ hours of agent session data on Windows + WSL1:

- **Sidecar count: held at exactly 3** (one set per live DB file) across the full reindex
- Survived a machine reboot + auto-resumed maintenance run with the same count

Compared to **788,972** orphan sidecars before the patch.

## Notes

- Best-effort: errors are dropped because sidecars are advisory and might already be gone (e.g. if a stale `Vfs::delete` raced with a concurrent open).
- The `close()` path with `delete_on_close=true` is a separate concern — handles are still open at that point so `fs::remove_file` would fail. Left as a follow-up.
- Does not change `WindowsOsLockFiles::open()` behavior or the lock semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)