### PR TITLE
fix(btree): revalidate reused cursor position before prechecked-absent table insert (+ index-path audit & regression suite)

### DIFF
--- a/crates/fsqlite-btree/src/cursor.rs
+++ b/crates/fsqlite-btree/src/cursor.rs
@@ -13247,6 +13247,300 @@ mod tests {
         );
     }
 
+    /// Deterministic index key whose record order equals the ordinal order:
+    /// a fixed-width big-endian blob field followed by the ordinal itself,
+    /// padded so every entry spills to overflow pages when `pad` exceeds the
+    /// page's max-local threshold.
+    fn ordered_index_key(i: i64, pad: usize) -> Vec<u8> {
+        let mut blob = i.to_be_bytes().to_vec();
+        blob.resize(8 + pad, 0xC3);
+        serialize_record(&[SqliteValue::Blob(blob.into()), SqliteValue::Integer(i)])
+    }
+
+    /// Deterministic xorshift so "hash-shaped" (uniformly scattered) unique
+    /// keys are reproducible without any external randomness.
+    fn xorshift64(state: &mut u64) -> u64 {
+        let mut x = *state;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        *state = x;
+        x
+    }
+
+    /// INSERT-only drift audit for UNIQUE index b-trees: scattered
+    /// ("hash-shaped") unique keys inserted through the canonical unique
+    /// probe path (`index_insert_unique_with_rightmost_report` — exactly
+    /// what a UNIQUE autoindex `IdxInsert` executes when the monotonic
+    /// fast-append hint does not apply) must keep EVERY key seek-reachable
+    /// across the many leaf/interior splits such a workload forces. Small
+    /// pages keep the tree deep so interior splits and fell-off-right-edge
+    /// probe restores (the interior-separator successor shape) are hit
+    /// constantly.
+    #[test]
+    fn test_unique_index_scattered_insert_only_keys_stay_seek_reachable() {
+        let cx = Cx::new();
+        let root = pn(2);
+        let store = MemPageStore::with_empty_index(root, 512);
+        let mut cursor = BtCursor::new(store, root, 512, false);
+
+        let key_count = 5_000_u64;
+        let mut state = 0x9E37_79B9_7F4A_7C15_u64;
+        let mut keys = Vec::with_capacity(key_count as usize);
+        for i in 0..key_count {
+            // 64 hex chars — the shape of a content-hash key — plus the
+            // rowid suffix, matching a UNIQUE autoindex record layout.
+            let a = xorshift64(&mut state);
+            let b = xorshift64(&mut state);
+            let hash = format!("{a:016x}{b:016x}{a:016x}{b:016x}");
+            #[allow(clippy::cast_possible_wrap)]
+            let key = serialize_record(&[
+                SqliteValue::Text(hash.into()),
+                SqliteValue::Integer(i as i64 + 1),
+            ]);
+            keys.push(key);
+        }
+
+        for (i, key) in keys.iter().enumerate() {
+            cursor
+                .index_insert_unique_with_rightmost_report(&cx, key, 1, "a.h")
+                .unwrap_or_else(|error| panic!("unique insert {i} must succeed: {error}"));
+        }
+
+        let mut misses = Vec::new();
+        for (i, key) in keys.iter().enumerate() {
+            if cursor.index_move_to(&cx, key).unwrap() != SeekResult::Found {
+                misses.push(i);
+            }
+        }
+        assert!(
+            misses.is_empty(),
+            "insert-only unique workload lost {} of {key_count} keys to \
+             out-of-order placement; first missing insert ordinals: {:?}",
+            misses.len(),
+            &misses[..misses.len().min(10)]
+        );
+        validate_index_tree_invariants(&mut cursor, root)
+            .expect("index tree invariants must hold after scattered inserts");
+        assert_eq!(
+            scan_all_index_keys(&mut cursor, &cx).unwrap().len(),
+            key_count as usize
+        );
+    }
+
+    /// INSERT-only drift audit, monotonic variant: ascending unique keys
+    /// driven through the same fast-append-then-fallback loop the VDBE
+    /// `IdxInsert` uses (`index_append_after_current_rightmost_position`,
+    /// falling back to the unique probe when the right-edge reuse declines,
+    /// e.g. immediately after a split cleared the cursor stack). Every key
+    /// must stay seek-reachable and the tree well-formed.
+    #[test]
+    fn test_unique_index_monotonic_fast_append_across_splits_stays_seek_reachable() {
+        let cx = Cx::new();
+        let root = pn(2);
+        let store = MemPageStore::with_empty_index(root, 512);
+        let mut cursor = BtCursor::new(store, root, 512, false);
+
+        let key_count = 4_000_i64;
+        let make_key = |i: i64| ordered_index_key(i, 40);
+        let mut fast_hits = 0usize;
+        let mut fallbacks = 0usize;
+
+        cursor
+            .index_insert_unique_with_rightmost_report(&cx, &make_key(1), 1, "a.h")
+            .unwrap();
+        for i in 2..=key_count {
+            let key = make_key(i);
+            // Engine shape: try the right-edge append reuse first; on decline
+            // (stale/cleared stack, e.g. after the previous insert split the
+            // leaf) fall back to the canonical unique probe.
+            if cursor
+                .index_append_after_current_rightmost_position(&cx, &key)
+                .unwrap()
+            {
+                fast_hits += 1;
+            } else {
+                fallbacks += 1;
+                cursor
+                    .index_insert_unique_with_rightmost_report(&cx, &key, 1, "a.h")
+                    .unwrap();
+            }
+        }
+        assert!(
+            fast_hits > 0,
+            "monotonic workload must exercise the fast-append reuse \
+             (hits={fast_hits}, fallbacks={fallbacks})"
+        );
+
+        let mut misses = Vec::new();
+        for i in 1..=key_count {
+            if cursor.index_move_to(&cx, &make_key(i)).unwrap() != SeekResult::Found {
+                misses.push(i);
+            }
+        }
+        assert!(
+            misses.is_empty(),
+            "monotonic fast-append workload lost {} of {key_count} keys \
+             (fast_hits={fast_hits}, fallbacks={fallbacks}); first: {:?}",
+            misses.len(),
+            &misses[..misses.len().min(10)]
+        );
+        validate_index_tree_invariants(&mut cursor, root)
+            .expect("index tree invariants must hold after monotonic appends");
+        assert_eq!(
+            i64::try_from(scan_all_index_keys(&mut cursor, &cx).unwrap().len()).unwrap(),
+            key_count
+        );
+    }
+
+    /// Sibling audit of the 83e0f563 table bug, INDEX side, canonical paths:
+    /// an UPDATE-shaped delete+reinsert on an index B-tree must keep every
+    /// key seek-reachable even when the delete drains a singleton leaf and
+    /// rebalances (the exact shape that broke the TABLE prechecked-absent
+    /// reuse). Production index maintenance (IdxDelete + IdxInsert, the
+    /// without-rowid UPDATE flow, and `native_replace_row`) always reinserts
+    /// through a fresh root-to-leaf seek — `index_insert` or the unique-probe
+    /// path — so this must hold by construction; this test pins it against a
+    /// deep tree with overflow-sized keys.
+    #[test]
+    fn test_index_delete_reinsert_via_canonical_paths_stays_seek_consistent() {
+        let cx = Cx::new();
+        let root = pn(2);
+        let store = MemPageStore::with_empty_index(root, USABLE);
+        let mut cursor = BtCursor::new(store, root, USABLE, false);
+
+        // Overflow-sized keys (> the index max-local threshold for a 4096
+        // usable page) build a deep multi-level tree; pass 1 thins the tree
+        // so pass-2 deletes drain singleton leaves and force rebalances.
+        let key_count = 400_i64;
+        let pad = 1400usize;
+        for i in 1..=key_count {
+            cursor
+                .index_insert(&cx, &ordered_index_key(i, pad))
+                .unwrap();
+        }
+        for i in (2..=key_count).step_by(2) {
+            assert!(
+                cursor
+                    .index_move_to(&cx, &ordered_index_key(i, pad))
+                    .unwrap()
+                    .is_found(),
+                "key {i} must be reachable before thinning"
+            );
+            cursor.delete(&cx).unwrap();
+        }
+
+        // UPDATE-shaped rewrite of every surviving key: position, delete,
+        // reinsert the same key through the two canonical production paths.
+        for i in (1..=key_count).step_by(2) {
+            let key = ordered_index_key(i, pad);
+            assert!(
+                cursor.index_move_to(&cx, &key).unwrap().is_found(),
+                "key {i} must be reachable before its rewrite"
+            );
+            cursor.delete(&cx).unwrap();
+            if i % 4 == 1 {
+                cursor.index_insert(&cx, &key).unwrap();
+            } else {
+                cursor
+                    .index_insert_unique_with_rightmost_report(&cx, &key, 1, "t.c")
+                    .unwrap();
+            }
+        }
+
+        let mut misses = Vec::new();
+        for i in (1..=key_count).step_by(2) {
+            if cursor
+                .index_move_to(&cx, &ordered_index_key(i, pad))
+                .unwrap()
+                != SeekResult::Found
+            {
+                misses.push(i);
+            }
+        }
+        assert!(
+            misses.is_empty(),
+            "keys must stay seek-reachable after canonical rewrites: {misses:?}"
+        );
+        validate_index_tree_invariants(&mut cursor, root)
+            .expect("index tree invariants must hold after rewrites");
+        assert_eq!(
+            i64::try_from(scan_all_index_keys(&mut cursor, &cx).unwrap().len()).unwrap(),
+            key_count / 2
+        );
+    }
+
+    /// Canary for the hypothetical INDEX sibling of the 83e0f563 table bug:
+    /// deliberately MISUSE `index_insert_prechecked_absent` across a
+    /// `delete()` (reusing the post-delete position without a fresh seek) and
+    /// assert the failure mode stays LOUD, never silent.
+    ///
+    /// Unlike the table side — where the post-delete successor position can
+    /// silently sit across a stale ancestor separator and blind reinsertion
+    /// commits an out-of-order tree — the index side is structurally
+    /// protected: after a drain+rebalance, `delete()` re-anchors with a fresh
+    /// seek, and an index entry's cross-leaf successor is an ancestor
+    /// SEPARATOR (interior position), which
+    /// `index_insert_from_current_position` rejects with a hard error instead
+    /// of inserting out of order. This canary pins that property: if seek
+    /// successor normalization ever changes to cross into the next leaf the
+    /// way the table path does, the misuse below would start corrupting
+    /// silently and this test would fail.
+    #[test]
+    fn test_index_prechecked_absent_misuse_after_delete_fails_loud_never_corrupts() {
+        let cx = Cx::new();
+        let root = pn(2);
+        let store = MemPageStore::with_empty_index(root, 512);
+        let mut cursor = BtCursor::new(store, root, 512, false);
+
+        let key_count = 400_i64;
+        for i in 1..=key_count {
+            cursor.index_insert(&cx, &ordered_index_key(i, 0)).unwrap();
+        }
+        // Thin to singletons so pass-2 deletes drain leaves and rebalance.
+        for i in (2..=key_count).step_by(2) {
+            assert!(
+                cursor
+                    .index_move_to(&cx, &ordered_index_key(i, 0))
+                    .unwrap()
+                    .is_found()
+            );
+            cursor.delete(&cx).unwrap();
+        }
+
+        for i in (1..=key_count).step_by(2) {
+            let key = ordered_index_key(i, 0);
+            assert!(
+                cursor.index_move_to(&cx, &key).unwrap().is_found(),
+                "key {i} must be reachable before its rewrite"
+            );
+            cursor.delete(&cx).unwrap();
+            // Blind reuse of the post-delete position. Allowed outcomes:
+            // success (position was admissible) or a hard error (position was
+            // an interior separator / empty stack). A hard error must leave
+            // the key re-insertable through the canonical path. What must
+            // NEVER happen is a silent out-of-order insert; the final sweep
+            // below catches that as a seek miss or invariant violation.
+            if cursor.index_insert_prechecked_absent(&cx, &key).is_err() {
+                cursor.index_insert(&cx, &key).unwrap();
+            }
+        }
+
+        let mut misses = Vec::new();
+        for i in (1..=key_count).step_by(2) {
+            if cursor.index_move_to(&cx, &ordered_index_key(i, 0)).unwrap() != SeekResult::Found {
+                misses.push(i);
+            }
+        }
+        assert!(
+            misses.is_empty(),
+            "misused prechecked reinsert silently corrupted the index; \
+             unreachable keys: {misses:?}"
+        );
+        validate_index_tree_invariants(&mut cursor, root)
+            .expect("index tree invariants must hold after misuse sweep");
+    }
+
     #[test]
     fn test_index_insert_unique_no_conflict_inserts_between_adjacent_prefixes() {
         let store = MemPageStore::with_empty_index(pn(2), USABLE);

--- a/crates/fsqlite-btree/src/cursor.rs
+++ b/crates/fsqlite-btree/src/cursor.rs
@@ -2962,6 +2962,112 @@ impl<P: PageReader> BtCursor<P> {
         Self::read_child_at_offset(entry.page_data.as_bytes(), cell_offset)
     }
 
+    /// Read the separator rowid of an interior TABLE cell.
+    ///
+    /// Interior table cells are `[4-byte left child][rowid varint]`; this
+    /// decodes just the rowid, mirroring the inline probe in
+    /// `binary_search_table_interior`.
+    fn table_interior_key_at(entry: &StackEntry, cell_idx: u16) -> Result<i64> {
+        let cell_offset = usize::from(Self::read_stack_entry_cell_pointer_inline(entry, cell_idx)?);
+        let cell_data = entry
+            .page_data
+            .as_bytes()
+            .get(cell_offset..)
+            .ok_or_else(|| FrankenError::DatabaseCorrupt {
+                detail: format!(
+                    "interior table cell pointer {} points past page end (len {})",
+                    cell_offset,
+                    entry.page_data.as_bytes().len()
+                ),
+            })?;
+        if cell_data.len() < 4 {
+            return Err(FrankenError::DatabaseCorrupt {
+                detail: "interior table cell too short for child pointer".to_owned(),
+            });
+        }
+        let Some((key, _)) = read_varint(&cell_data[4..]) else {
+            return Err(FrankenError::DatabaseCorrupt {
+                detail: "interior table cell has invalid rowid varint".to_owned(),
+            });
+        };
+        #[allow(clippy::cast_possible_wrap)]
+        Ok(key as i64)
+    }
+
+    /// Whether the cursor's CURRENT position is an admissible insertion point
+    /// for `rowid` in a table B-tree: the landing leaf's local key order AND
+    /// every ancestor separator on the descent path must place `rowid` in
+    /// exactly this slot.
+    ///
+    /// Callers that reuse a position they did not just seek (notably the
+    /// UPDATE delete+reinsert flow through `table_insert_prechecked_absent`)
+    /// need this check: a delete that drains the last cell of a subtree
+    /// leaves the cursor on the FIRST leaf of the NEXT subtree, across one or
+    /// more ancestor separators. Reinserting the same rowid there writes a
+    /// key that is <= a separator into that separator's right-hand subtree —
+    /// an out-of-order tree that stock SQLite reports as "Rowid out of
+    /// order" and that rowid seeks can no longer reach (observed in the
+    /// field as "table rowid seek on root N missed scan-visible rowid R on
+    /// successor page P"). Leaf-local order alone cannot catch this: the
+    /// landing leaf itself stays sorted.
+    fn current_position_admits_table_insert(&self, rowid: i64) -> Result<bool> {
+        let Some(top) = self.stack.last() else {
+            return Ok(false);
+        };
+        if !(top.header.page_type.is_leaf() && top.header.page_type.is_table()) {
+            return Ok(false);
+        }
+
+        // Leaf-local bounds around the insertion slot.
+        if top.header.cell_count > 0 {
+            if self.at_eof {
+                let last = Self::table_leaf_rowid_at(top, top.header.cell_count - 1)?;
+                if last >= rowid {
+                    return Ok(false);
+                }
+            } else {
+                if top.cell_idx >= top.header.cell_count {
+                    return Ok(false);
+                }
+                let successor = Self::table_leaf_rowid_at(top, top.cell_idx)?;
+                if successor <= rowid {
+                    return Ok(false);
+                }
+                if top.cell_idx > 0 {
+                    let predecessor = Self::table_leaf_rowid_at(top, top.cell_idx - 1)?;
+                    if predecessor >= rowid {
+                        return Ok(false);
+                    }
+                }
+            }
+        } else if !self.at_eof {
+            return Ok(false);
+        }
+
+        // Ancestor separators along the descent path. Descending through
+        // cell_idx means everything in that subtree must be
+        // > separator[cell_idx - 1] and <= separator[cell_idx].
+        for entry in self.stack.iter().rev().skip(1) {
+            if !entry.header.page_type.is_interior() {
+                return Ok(false);
+            }
+            let idx = entry.cell_idx;
+            if idx > 0 {
+                let lower = Self::table_interior_key_at(entry, idx - 1)?;
+                if lower >= rowid {
+                    return Ok(false);
+                }
+            }
+            if idx < entry.header.cell_count {
+                let upper = Self::table_interior_key_at(entry, idx)?;
+                if upper < rowid {
+                    return Ok(false);
+                }
+            }
+        }
+        Ok(true)
+    }
+
     fn record_depth_gauge(&mut self, cx: &Cx) -> Result<()> {
         let depth = if self.stack.is_empty() {
             match self.last_known_depth {
@@ -9407,6 +9513,27 @@ impl<P: PageWriter> BtCursor<P> {
         data: &[u8],
     ) -> Result<()> {
         let result = self.with_btree_op(cx, BtreeOpType::Insert, |cursor| {
+            // The caller proved `rowid` is absent, but the position it is
+            // reusing (typically the successor left behind by `delete()` in
+            // the UPDATE delete+reinsert flow) may sit on the wrong side of
+            // an ancestor separator: deleting the last cell of a subtree
+            // repositions the cursor onto the first leaf of the NEXT
+            // subtree. Blindly inserting there commits an out-of-order tree
+            // ("Rowid out of order" under stock SQLite integrity_check;
+            // rowid seeks then miss a scan-visible row). Revalidate the
+            // position and fall back to a fresh root-to-leaf insert seek
+            // when it is not an admissible slot for `rowid`.
+            if !cursor.current_position_admits_table_insert(rowid)? {
+                cursor.clear_seek_cache();
+                let reseek = cursor.table_seek_for_insert(cx, rowid)?;
+                if reseek.is_found() {
+                    return Err(FrankenError::DatabaseCorrupt {
+                        detail: format!(
+                            "rowid {rowid} appeared during prechecked-absent insert revalidation"
+                        ),
+                    });
+                }
+            }
             cursor.table_insert_from_current_position(cx, rowid, data)
         });
         if result.is_ok() {
@@ -12021,6 +12148,67 @@ mod tests {
             cursor.payload(&cx).unwrap(),
             format!("row-{}", row_count - 1).as_bytes()
         );
+    }
+
+    /// Regression: an UPDATE-shaped delete+reinsert of a row that is (a) the
+    /// sole cell of its leaf and (b) the maximum of a subtree whose separator
+    /// lives at grandparent-or-higher level must NOT relocate the row across
+    /// that separator.
+    ///
+    /// Pre-fix, `delete()` of such a row drained and freed its leaf and left
+    /// the cursor on the first leaf of the NEXT subtree;
+    /// `table_insert_prechecked_absent` then reinserted the rowid there,
+    /// committing a tree where the stale (still legal) ancestor separator
+    /// routes rowid seeks into the left subtree while the row now lives in
+    /// the right one: scans see the row, `table_move_to` errors with "table
+    /// rowid seek on root N missed scan-visible rowid R on successor page P",
+    /// and stock SQLite integrity_check reports "Rowid out of order".
+    /// Observed in the field on a CAS blob store where every multi-KB row
+    /// occupies its own leaf and a route-guard UPDATE rewrites rows in place.
+    #[test]
+    fn test_prechecked_absent_reinsert_does_not_cross_ancestor_separator() {
+        let cx = Cx::new();
+        let root = PageNumber::new(2).unwrap();
+        let store = MemPageStore::with_empty_table(root, USABLE);
+        let mut cursor = BtCursor::new(store, root, USABLE, true);
+
+        // Payloads big enough that every leaf holds exactly one cell, and
+        // enough rows to force a depth-3 tree, so some subtree separators
+        // live at the ROOT while leaves hang two levels below.
+        let row_count = 700_i64;
+        let payload = vec![0xA5u8; 3500];
+        for rowid in 1..=row_count {
+            cursor.table_insert(&cx, rowid, &payload).unwrap();
+        }
+
+        // UPDATE-shaped rewrite of EVERY row: position, delete, reinsert the
+        // same rowid through the prechecked-absent fast path (exactly what
+        // the direct UPDATE flow does when the in-place overwrite declines).
+        for rowid in 1..=row_count {
+            assert!(
+                cursor.table_move_to(&cx, rowid).unwrap().is_found(),
+                "rowid {rowid} must be reachable before its rewrite"
+            );
+            cursor.delete(&cx).unwrap();
+            cursor
+                .table_insert_prechecked_absent(&cx, rowid, &payload)
+                .unwrap();
+        }
+
+        // Every row must still be reachable by a rowid seek (pre-fix the
+        // divider-equal rows failed with the missed-scan-visible error), and
+        // the in-order scan must agree with the seeks.
+        for rowid in 1..=row_count {
+            let seek = cursor.table_move_to(&cx, rowid).unwrap_or_else(|error| {
+                panic!("rowid {rowid} seek must not error after rewrite: {error}")
+            });
+            assert_eq!(
+                seek,
+                SeekResult::Found,
+                "rowid {rowid} must remain seek-reachable after its rewrite"
+            );
+        }
+        assert_eq!(cursor.count_all_rows(&cx).unwrap(), row_count);
     }
 
     /// Helper: build a leaf table page with sorted (rowid, payload) entries.

--- a/crates/fsqlite/tests/insert_only_unique_index_consistency.rs
+++ b/crates/fsqlite/tests/insert_only_unique_index_consistency.rs
@@ -1,0 +1,180 @@
+//! INSERT-dominated drift audit for UNIQUE (auto)indexes at the SQL level:
+//! under a sustained insert workload of hash-shaped unique keys — including
+//! a mid-stream REINDEX and the OR IGNORE / OR REPLACE conflict flows an
+//! ingest pipeline produces — every inserted key must remain reachable
+//! through the index probe. The decisive oracle is the UNIQUE constraint
+//! itself: re-inserting an existing key MUST fail — the uniqueness probe is
+//! an index seek, so a key that landed out of b-tree order (unreachable by
+//! seek) would let the duplicate through. A full-scan count and
+//! `PRAGMA integrity_check` back it up.
+//!
+//! Companion coverage to the b-tree-level tests
+//! `test_unique_index_scattered_insert_only_keys_stay_seek_reachable` and
+//! `test_unique_index_monotonic_fast_append_across_splits_stays_seek_reachable`
+//! (crates/fsqlite-btree/src/cursor.rs): this exercises the same two cursor
+//! primitives through the whole VDBE `IdxInsert` flow, including the
+//! rightmost fast-append hint bookkeeping that persists across rows of the
+//! statement stream.
+//!
+//! All data is synthetic (deterministic xorshift), sized so the index b-tree
+//! goes multiple levels deep and splits constantly.
+
+use fsqlite::Connection;
+use fsqlite_types::SqliteValue;
+
+const ROWS: u64 = 3000;
+
+fn xorshift64(state: &mut u64) -> u64 {
+    let mut x = *state;
+    x ^= x << 13;
+    x ^= x >> 7;
+    x ^= x << 17;
+    *state = x;
+    x
+}
+
+/// 192-hex-char scattered key (hash-shaped), deterministic per ordinal.
+fn scattered_key(state: &mut u64) -> String {
+    let a = xorshift64(state);
+    let b = xorshift64(state);
+    let c = xorshift64(state);
+    format!("{a:016x}{b:016x}{c:016x}").repeat(4)
+}
+
+/// Ascending key with the same footprint, for the fast-append hint path.
+fn ascending_key(i: u64) -> String {
+    format!("{i:048x}").repeat(4)
+}
+
+fn count_one(c: &Connection, sql: &str) -> i64 {
+    let rows = c.query(sql).unwrap();
+    match rows.first().and_then(|row| row.values().first().cloned()) {
+        Some(SqliteValue::Integer(n)) => n,
+        other => panic!("expected integer from `{sql}`, got {other:?}"),
+    }
+}
+
+fn assert_integrity_ok(c: &Connection, label: &str) {
+    let rows = c.query("PRAGMA integrity_check").unwrap();
+    let msgs: Vec<SqliteValue> = rows.iter().flat_map(|row| row.values().to_vec()).collect();
+    assert_eq!(
+        msgs,
+        vec![SqliteValue::Text("ok".into())],
+        "integrity_check after {label}"
+    );
+}
+
+fn run_workload(keys: &[String], label: &str) {
+    let c = Connection::open(":memory:").unwrap();
+    c.execute("CREATE TABLE a (id INTEGER PRIMARY KEY, h TEXT UNIQUE, body BLOB)")
+        .unwrap();
+
+    // Phase 1: load the first half, then REINDEX (rebuilds the unique index
+    // btree), then keep inserting into the rebuilt index — the sequence that
+    // must NOT re-introduce drift.
+    let half = keys.len() / 2;
+    for (i, h) in keys.iter().take(half).enumerate() {
+        let body = format!("{:02X}", i % 251).repeat(120);
+        c.execute(&format!(
+            "INSERT INTO a VALUES ({}, '{h}', X'{body}')",
+            i + 1
+        ))
+        .unwrap_or_else(|error| panic!("{label}: insert {i} must succeed: {error}"));
+    }
+    c.execute("REINDEX").unwrap();
+
+    // Phase 2: the remaining inserts, interleaved with the conflict-handling
+    // flows an ingest workload produces: INSERT OR IGNORE re-puts of an
+    // already-present key (index-conflict rollback path) and INSERT OR
+    // REPLACE re-puts (conflict row + index-entry replacement path).
+    for (i, h) in keys.iter().enumerate().skip(half) {
+        let body = format!("{:02X}", i % 251).repeat(120);
+        c.execute(&format!(
+            "INSERT INTO a VALUES ({}, '{h}', X'{body}')",
+            i + 1
+        ))
+        .unwrap_or_else(|error| panic!("{label}: insert {i} must succeed: {error}"));
+        if i % 8 == 0 {
+            let re_put = &keys[i / 2];
+            c.execute(&format!(
+                "INSERT OR IGNORE INTO a VALUES ({}, '{re_put}', X'AA')",
+                2_000_000 + i
+            ))
+            .unwrap_or_else(|error| {
+                panic!("{label}: OR IGNORE re-put {i} must not error: {error}")
+            });
+        }
+        if i % 13 == 0 {
+            let re_put = &keys[i / 3];
+            let body = format!("{:02X}", (i + 1) % 251).repeat(120);
+            c.execute(&format!(
+                "INSERT OR REPLACE INTO a VALUES ({}, '{re_put}', X'{body}')",
+                (i / 3) + 1
+            ))
+            .unwrap_or_else(|error| {
+                panic!("{label}: OR REPLACE re-put {i} must not error: {error}")
+            });
+        }
+    }
+    assert_eq!(
+        count_one(&c, "SELECT count(*) FROM a"),
+        i64::try_from(keys.len()).unwrap(),
+        "{label}: row count after load"
+    );
+
+    // Oracle 1: every key must be refused as a duplicate. The uniqueness
+    // probe is an index seek; a key that landed out of order would be
+    // invisible to it and the duplicate would slip through.
+    let mut slipped = Vec::new();
+    for (i, h) in keys.iter().enumerate() {
+        let dup = c.execute(&format!(
+            "INSERT INTO a VALUES ({}, '{h}', X'00')",
+            1_000_000 + i
+        ));
+        if dup.is_ok() {
+            slipped.push(i);
+        }
+    }
+    assert!(
+        slipped.is_empty(),
+        "{label}: {} of {} keys were not visible to the UNIQUE probe \
+         (index entry unreachable by seek); first insert ordinals: {:?}",
+        slipped.len(),
+        keys.len(),
+        &slipped[..slipped.len().min(10)]
+    );
+
+    // Oracle 2: no duplicate insert may have slipped through and no row may
+    // have been lost.
+    assert_eq!(
+        count_one(&c, "SELECT count(*) FROM a"),
+        i64::try_from(keys.len()).unwrap(),
+        "{label}: row count after duplicate probes"
+    );
+    assert_eq!(
+        count_one(&c, "SELECT count(DISTINCT h) FROM a"),
+        i64::try_from(keys.len()).unwrap(),
+        "{label}: distinct key count"
+    );
+
+    // Oracle 3: structural verification.
+    assert_integrity_ok(&c, label);
+}
+
+/// Scattered (hash-shaped) unique keys: the shape of a content-hash digest
+/// column. Exercises the canonical unique-probe insert on every row, with
+/// constant leaf and interior splits.
+#[test]
+fn insert_only_unique_index_scattered_keys_probe_every_row() {
+    let mut state = 0xDEAD_BEEF_CAFE_F00D_u64;
+    let keys: Vec<String> = (0..ROWS).map(|_| scattered_key(&mut state)).collect();
+    run_workload(&keys, "scattered");
+}
+
+/// Ascending unique keys: enables the VDBE rightmost fast-append hint on
+/// most rows (with fallback re-probes right after splits).
+#[test]
+fn insert_only_unique_index_ascending_keys_probe_every_row() {
+    let keys: Vec<String> = (1..=ROWS).map(ascending_key).collect();
+    run_workload(&keys, "ascending");
+}

--- a/crates/fsqlite/tests/update_overflow_indexed_seek_consistency.rs
+++ b/crates/fsqlite/tests/update_overflow_indexed_seek_consistency.rs
@@ -1,0 +1,267 @@
+//! Sibling audit of the prechecked-absent cursor-reuse corruption (table side
+//! fixed by "fix(btree): revalidate reused cursor position before
+//! prechecked-absent table insert"): a workload of repeated UPDATEs that
+//! rewrite overflow-payload rows on INDEXED tables must keep every row
+//! reachable through the index seek path (not just full scans), and
+//! `PRAGMA integrity_check` must stay clean.
+//!
+//! Covers the three index-maintenance flows that reinsert entries after a
+//! delete:
+//!   * non-indexed-column UPDATE on an indexed rowid table (direct-update
+//!     delete+reinsert on the TABLE btree, with the index left in place);
+//!   * indexed-column UPDATE through a NON-UNIQUE index (IdxDelete +
+//!     IdxInsert full-seek path);
+//!   * indexed-column UPDATE through a UNIQUE index (IdxDelete + the
+//!     unique-probe insert path that reuses its own fresh probe position);
+//!   * WITHOUT ROWID table UPDATE (delete-at-position + unique reinsert on
+//!     the index-structured table btree), including a PK rewrite pass.
+//!
+//! All data is synthetic. Payload sizes are chosen so both the table rows
+//! and the index keys spill to overflow pages, and row counts are large
+//! enough that the btrees are multi-level, so deletes drain leaves and
+//! rebalance — the shape that broke the table-side prechecked reuse.
+
+use fsqlite::Connection;
+use fsqlite_types::SqliteValue;
+
+const ROWS: i64 = 120;
+const KEY_PAD: usize = 1100; // > index max-local for 4096-byte pages
+const BLOB_HEX_BYTES: usize = 2600; // > table max-local once hex-expanded
+
+fn key(i: i64, pass: usize) -> String {
+    // Deterministic, strictly ordered by i within a pass; rotating the pad
+    // character per pass forces real index-entry rewrites on k-updates.
+    let pad_char = match pass {
+        0 => 'a',
+        1 => 'b',
+        _ => 'c',
+    };
+    format!("k{i:06}-{}", pad_char.to_string().repeat(KEY_PAD))
+}
+
+fn blob_hex(i: i64, pass: usize) -> String {
+    let byte = (i % 251 + pass as i64) % 256;
+    format!("{byte:02X}").repeat(BLOB_HEX_BYTES)
+}
+
+fn has_op(c: &Connection, sql: &str, prefix: &str) -> bool {
+    c.query(&format!("EXPLAIN {sql}")).unwrap().iter().any(
+        |row| matches!(row.values().get(1), Some(SqliteValue::Text(o)) if o.to_string().starts_with(prefix)),
+    )
+}
+
+fn assert_integrity_ok(c: &Connection, label: &str) {
+    let rows = c.query("PRAGMA integrity_check").unwrap();
+    let msgs: Vec<SqliteValue> = rows.iter().flat_map(|row| row.values().to_vec()).collect();
+    assert_eq!(
+        msgs,
+        vec![SqliteValue::Text("ok".into())],
+        "integrity_check after {label}"
+    );
+}
+
+fn count_where(c: &Connection, sql: &str) -> i64 {
+    let rows = c.query(sql).unwrap();
+    match rows.first().and_then(|row| row.values().first().cloned()) {
+        Some(SqliteValue::Integer(n)) => n,
+        other => panic!("expected integer count from `{sql}`, got {other:?}"),
+    }
+}
+
+fn assert_indexed_seek_finds_every_row(
+    c: &Connection,
+    table: &str,
+    key_col: &str,
+    pass: usize,
+    expect_seek_plan: bool,
+    label: &str,
+) {
+    // For indexed rowid tables the probe plan must contain the index seek
+    // path (SeekGE). The engine's plan also carries a verify-by-scan
+    // fallback branch, so the count alone cannot prove the seek found the
+    // row; the `PRAGMA integrity_check` calls in each test are what would
+    // flag an out-of-order entry. (WITHOUT ROWID SELECT probes currently
+    // compile to a scan in this engine, so no plan assertion there — the
+    // UPDATE statements' own NoConflict PK seeks, verified by re-reading
+    // each rewritten row, are the seek-consistency check for that layout.)
+    let probe = format!(
+        "SELECT count(*) FROM {table} WHERE {key_col} = '{}'",
+        key(1, pass)
+    );
+    if expect_seek_plan {
+        assert!(
+            has_op(c, &probe, "SeekGE"),
+            "probe must plan an index seek (SeekGE): `{probe}`"
+        );
+    }
+    for i in 1..=ROWS {
+        let seek = count_where(
+            c,
+            &format!(
+                "SELECT count(*) FROM {table} WHERE {key_col} = '{}'",
+                key(i, pass)
+            ),
+        );
+        assert_eq!(seek, 1, "{label}: index seek must find row {i}");
+    }
+    let total = count_where(c, &format!("SELECT count(*) FROM {table}"));
+    assert_eq!(total, ROWS, "{label}: full scan row count");
+}
+
+/// Rowid table with a NON-UNIQUE index over an overflow-sized TEXT key.
+#[test]
+fn update_overflow_rows_nonunique_index_stays_seek_consistent() {
+    let c = Connection::open(":memory:").unwrap();
+    c.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, k TEXT, v BLOB)")
+        .unwrap();
+    c.execute("CREATE INDEX idx_t_k ON t(k)").unwrap();
+    for i in 1..=ROWS {
+        c.execute(&format!(
+            "INSERT INTO t VALUES ({i}, '{}', X'{}')",
+            key(i, 0),
+            blob_hex(i, 0)
+        ))
+        .unwrap();
+    }
+    assert_indexed_seek_finds_every_row(&c, "t", "k", 0, true, "after load");
+
+    // Pass 1: rewrite only the overflow BLOB (table-btree delete+reinsert;
+    // index untouched). This is the SQL surface of the fixed table bug.
+    for i in 1..=ROWS {
+        assert_eq!(
+            c.execute(&format!(
+                "UPDATE t SET v = X'{}' WHERE id = {i}",
+                blob_hex(i, 1)
+            ))
+            .unwrap(),
+            1,
+            "blob rewrite must update row {i}"
+        );
+    }
+    assert_indexed_seek_finds_every_row(&c, "t", "k", 0, true, "after blob rewrites");
+    assert_integrity_ok(&c, "blob rewrites (non-unique index)");
+
+    // Pass 2: rewrite the INDEXED overflow key itself (IdxDelete+IdxInsert).
+    for i in 1..=ROWS {
+        assert_eq!(
+            c.execute(&format!("UPDATE t SET k = '{}' WHERE id = {i}", key(i, 1)))
+                .unwrap(),
+            1,
+            "key rewrite must update row {i}"
+        );
+    }
+    assert_indexed_seek_finds_every_row(&c, "t", "k", 1, true, "after key rewrites");
+    assert_integrity_ok(&c, "key rewrites (non-unique index)");
+}
+
+/// Rowid table with a UNIQUE index over an overflow-sized TEXT key.
+#[test]
+fn update_overflow_rows_unique_index_stays_seek_consistent() {
+    let c = Connection::open(":memory:").unwrap();
+    c.execute("CREATE TABLE u (id INTEGER PRIMARY KEY, k TEXT, v BLOB)")
+        .unwrap();
+    c.execute("CREATE UNIQUE INDEX idx_u_k ON u(k)").unwrap();
+    for i in 1..=ROWS {
+        c.execute(&format!(
+            "INSERT INTO u VALUES ({i}, '{}', X'{}')",
+            key(i, 0),
+            blob_hex(i, 0)
+        ))
+        .unwrap();
+    }
+    assert_indexed_seek_finds_every_row(&c, "u", "k", 0, true, "after load");
+
+    for i in 1..=ROWS {
+        assert_eq!(
+            c.execute(&format!(
+                "UPDATE u SET v = X'{}' WHERE id = {i}",
+                blob_hex(i, 1)
+            ))
+            .unwrap(),
+            1
+        );
+    }
+    assert_indexed_seek_finds_every_row(&c, "u", "k", 0, true, "after blob rewrites");
+    assert_integrity_ok(&c, "blob rewrites (unique index)");
+
+    for i in 1..=ROWS {
+        assert_eq!(
+            c.execute(&format!("UPDATE u SET k = '{}' WHERE id = {i}", key(i, 1)))
+                .unwrap(),
+            1
+        );
+    }
+    assert_indexed_seek_finds_every_row(&c, "u", "k", 1, true, "after key rewrites");
+    assert_integrity_ok(&c, "key rewrites (unique index)");
+}
+
+/// WITHOUT ROWID table: rows live in an index-structured btree keyed by an
+/// overflow-sized TEXT primary key. UPDATEs are delete-at-position + unique
+/// reinsert on that btree.
+#[test]
+fn update_overflow_rows_without_rowid_stays_seek_consistent() {
+    let c = Connection::open(":memory:").unwrap();
+    c.execute("CREATE TABLE w (k TEXT PRIMARY KEY, v BLOB) WITHOUT ROWID")
+        .unwrap();
+    for i in 1..=ROWS {
+        c.execute(&format!(
+            "INSERT INTO w VALUES ('{}', X'{}')",
+            key(i, 0),
+            blob_hex(i, 0)
+        ))
+        .unwrap();
+    }
+    assert_indexed_seek_finds_every_row(&c, "w", "k", 0, false, "after load");
+
+    // NOTE: the WITHOUT ROWID UPDATE path currently reports 0 through
+    // `changes()` even when it rewrites a row (observed at HEAD; rowid-table
+    // UPDATEs report correctly). The assertions below therefore verify that
+    // each UPDATE actually took effect by re-reading the row through its
+    // PRIMARY KEY, which is also the seek-consistency check for this layout:
+    // the UPDATE's own PK probe AND the verification probe must both find
+    // the (re)inserted entry.
+
+    // Pass 1: rewrite the non-PK payload (same PK reinserted).
+    for i in 1..=ROWS {
+        c.execute(&format!(
+            "UPDATE w SET v = X'{}' WHERE k = '{}'",
+            blob_hex(i, 1),
+            key(i, 0)
+        ))
+        .unwrap();
+        assert_eq!(
+            count_where(
+                &c,
+                &format!(
+                    "SELECT count(*) FROM w WHERE k = '{}' AND v = X'{}'",
+                    key(i, 0),
+                    blob_hex(i, 1)
+                ),
+            ),
+            1,
+            "payload rewrite must be visible for row {i}"
+        );
+    }
+    assert_indexed_seek_finds_every_row(&c, "w", "k", 0, false, "after payload rewrites");
+    assert_integrity_ok(&c, "payload rewrites (without rowid)");
+
+    // Pass 2: rewrite the PRIMARY KEY itself (entry moves inside the btree).
+    for i in 1..=ROWS {
+        c.execute(&format!(
+            "UPDATE w SET k = '{}' WHERE k = '{}'",
+            key(i, 1),
+            key(i, 0)
+        ))
+        .unwrap();
+        assert_eq!(
+            count_where(
+                &c,
+                &format!("SELECT count(*) FROM w WHERE k = '{}'", key(i, 1)),
+            ),
+            1,
+            "pk rewrite must be visible for row {i}"
+        );
+    }
+    assert_indexed_seek_finds_every_row(&c, "w", "k", 1, false, "after pk rewrites");
+    assert_integrity_ok(&c, "pk rewrites (without rowid)");
+}


### PR DESCRIPTION

## Summary

A direct UPDATE that rewrites a row whose payload uses overflow pages can
commit an **out-of-order table b-tree**: the row stays visible to full scans
but becomes unreachable by rowid seek, stock `sqlite3` `integrity_check`
reports **"Rowid out of order"**, REINDEX does not repair it (the damage is
in the table b-tree, not any index), and VACUUM does (full rebuild).

This PR contains two commits:

1. **`83e0f563` — the fix.** `table_insert_prechecked_absent` now
   revalidates the cursor position it was asked to reuse — leaf-local key
   order AND every ancestor separator on the descent path — and falls back
   to a fresh root-to-leaf insert seek when the position is not an
   admissible slot for the rowid. One function, `fsqlite-btree` only.
2. **`1f0a12f3` — sibling audit + regression suite.** A full audit of every
   other cursor-reuse insert site in the engine (most importantly the INDEX
   insert paths, including UNIQUE-index inserts under sustained
   insert-dominated workloads) found **no second unguarded-and-reachable
   site**; this commit adds b-tree-level and SQL-level regression tests that
   pin the structural properties that conclusion rests on. No engine code
   changes.

## Symptom

Under a workload of repeated UPDATEs on overflow-payload rows (for example
an ingest pipeline that rewrites just-inserted multi-KB blob rows in place),
specific rows deterministically vanish from point lookups while remaining
scan-visible:

* `SELECT ... WHERE rowid = :r` misses; `SELECT count(*)` still counts the
  row; internally the engine surfaces
  `table rowid seek on root N missed scan-visible rowid R on successor page P`.
* Stock SQLite `PRAGMA integrity_check` on the produced file: `Rowid out of
  order`.
* `REINDEX` does not fix it; `VACUUM` does.

The affected rows are exactly those whose rowid equals a
grandparent-or-higher separator key in the table b-tree.

## Root cause

`execute_prepared_direct_simple_update` (and its fixed-width REAL variant)
rewrite a row as `delete()` followed by a reinsert of the same rowid through
`table_insert_prechecked_absent`, reusing the post-delete cursor position
without a re-seek (the USESEEKRESULT-style fast path).

When the deleted row was (a) the sole cell of its leaf and (b) the maximum
of a subtree whose separator lives at grandparent-or-higher level — the
steady state when every multi-KB row occupies its own leaf — `delete()`'s
rebalance drains and frees that leaf and leaves the cursor on the **first
leaf of the next subtree**, across the (stale but still legal) ancestor
separator. Table interior cells are routing copies, so the separator equal
to the deleted rowid legitimately survives the delete. Blindly reinserting
the same rowid at the reused position writes a key `<=` that separator into
the separator's right-hand subtree: the tree is now out of order, and every
rowid seek routes left at the separator and misses the row.

## Fix

`crates/fsqlite-btree/src/cursor.rs`:

* `current_position_admits_table_insert(rowid)` — checks that the reused
  position is an admissible insertion slot: leaf top, correct leaf-local
  neighbors, and every ancestor separator on the descent path brackets the
  rowid. Reads only pages already in the cursor stack.
* `table_insert_prechecked_absent` calls it first and, when the position is
  inadmissible, clears the seek cache and performs a fresh
  `table_seek_for_insert` (erroring with `DatabaseCorrupt` if the
  "prechecked absent" rowid has somehow appeared).

The common fast path — valid same-leaf reuse — is unaffected; the check adds
no page reads. Both storage backends are covered (the two VDBE cursor
backends instantiate the same generic `BtCursor`).

## Repro

`test_prechecked_absent_reinsert_does_not_cross_ancestor_separator`
(fails pre-fix, passes post-fix): 700 rows of 3.5 KB payloads build a
depth-3 table b-tree of singleton leaves, so some subtree separators live at
the root; an UPDATE-shaped `table_move_to` → `delete()` →
`table_insert_prechecked_absent` rewrite of every row must leave every rowid
seek-reachable. Pre-fix, the rows whose rowids equal root/grandparent
separator keys fail with the missed-scan-visible error.

Equivalent SQL-level shape: any UPDATE that rewrites an overflow row whose
rowid equals a grandparent separator key, e.g. repeated
`UPDATE t SET v = :blob WHERE id = :i` over multi-KB rows.

## Sibling audit (second commit): is the same pattern reachable elsewhere?

Every "prechecked absent" insert or cursor-reuse-across-mutation site in the
engine was audited (16 sites; classification: guarded / unguarded-but-
unreachable / unguarded-and-reachable). Result: **no second
unguarded-and-reachable site.** Highlights:

* `index_insert_prechecked_absent` shares the unguarded shape but its only
  caller is the UNIQUE-index probe insert, which performs its fresh probe
  seek in the same function with no intervening mutation, gates the reuse on
  a leaf-top check, and falls back to the full-seek `index_insert`
  otherwise. Deliberately misusing the primitive across `delete()` (the
  table bug's shape) cannot corrupt silently on an index b-tree: index
  interior cells are real entries (no stale equal separators), the seek's
  cross-leaf successor normalization stops on an interior separator, and
  `index_insert_from_current_position` rejects non-leaf tops with a hard
  error. A canary test pins this fail-loud property.
* The pure INSERT path into UNIQUE indexes — the canonical unique-probe
  insert and the rightmost fast-append reuse — was audited specifically for
  stale reuse across page splits: after any split `balance_for_insert`
  clears the cursor stack, which nulls the position stamp and drops the
  fast-append hint, forcing a re-probe; the no-split path refreshes the leaf
  state in place. Insert-only workloads of scattered (hash-shaped) and
  ascending unique keys across constant leaf/interior splits, including a
  mid-stream REINDEX and INSERT OR IGNORE / OR REPLACE conflict flows, could
  not produce a seek-unreachable index entry at either the b-tree or the SQL
  level. The discriminating oracle: an out-of-order index entry is invisible
  to the uniqueness probe, so its key would be accepted twice — the tests
  assert every duplicate is refused.
* All other reuse sites (VDBE `Insert`/`IdxInsert`/`IdxDelete` arms, REPLACE
  row replacement, WITHOUT ROWID UPDATE/upsert flows, table append hints,
  deferred direct-write runs, seek caches) either re-seek, revalidate
  against freshly read pages, or are invalidated by every mutation path.

## Test coverage added

b-tree level (`crates/fsqlite-btree/src/cursor.rs`):

* `test_prechecked_absent_reinsert_does_not_cross_ancestor_separator` —
  the fix's regression test (commit 1).
* `test_index_delete_reinsert_via_canonical_paths_stays_seek_consistent` —
  UPDATE-shaped delete+reinsert over a deep index tree of overflow-sized
  keys through the two production reinsert paths.
* `test_index_prechecked_absent_misuse_after_delete_fails_loud_never_corrupts`
  — fail-loud canary for the index primitive.
* `test_unique_index_scattered_insert_only_keys_stay_seek_reachable`,
  `test_unique_index_monotonic_fast_append_across_splits_stays_seek_reachable`
  — insert-only UNIQUE-index workloads across splits.

SQL level (`crates/fsqlite/tests/`):

* `update_overflow_indexed_seek_consistency.rs` — repeated UPDATEs
  rewriting overflow rows under a non-unique index, a unique index, and a
  WITHOUT ROWID primary key (including PK rewrites); index-probe plans and
  `PRAGMA integrity_check` verified after every pass.
* `insert_only_unique_index_consistency.rs` — insert-dominated UNIQUE
  autoindex workload with a mid-stream REINDEX and OR IGNORE / OR REPLACE
  interleavings; duplicate-refusal oracle plus counts and integrity_check.

All data in every test is synthetic (deterministic counters / xorshift).

## Affected versions

* The vulnerable call shape (direct-UPDATE `delete()` +
  `table_insert_prechecked_absent` reuse) is reachable and the corruption
  reproduces from **0.1.10 through 0.1.16 (current HEAD)**.
* The underlying b-tree-level defect also reproduces on **v0.1.9** (the
  primitive and the direct-UPDATE call site both ship in 0.1.9; the
  regression test body fails there at the b-tree API level). Users pinned to
  0.1.9 should treat it as affected as well.
* The INDEX insert paths have no equivalent defect at HEAD; the same b-tree
  probes also pass against v0.1.9.

## Notes for reviewers

* `cargo test -p fsqlite-btree`: 483 passed / 0 failed / 12 ignored with
  both commits (479 baseline at the branch base).
* The two SQL-level test files require `fsqlite-core` to build. Note that
  HEAD (`edf9852f`) calls the two-argument
  `Bulkhead::try_acquire(weight, now)`, which needs `asupersync >= 0.3.9`,
  while the committed `Cargo.lock` still pins 0.3.5 — `fsqlite-core` does
  not compile with the committed lockfile as-is. The new tests were verified
  with the lock locally resolved to the already-published asupersync 0.3.9;
  reconciling the lockfile belongs with the `edf9852f` line rather than this
  PR.
* Pre-existing at the branch base, unrelated to these commits:
  `cargo fmt --check` fails in several `crates/fsqlite/tests/*_oracle.rs`
  files, and `fsqlite-vdbe` has one failing plan-shape test
  (`bd_2dgf5_rowid_equality_aggregate_seeks_single_row`). Files touched by
  this PR are rustfmt-clean.
* Observed while writing the WITHOUT ROWID coverage (pre-existing, out of
  scope here): WITHOUT ROWID UPDATEs report 0 through `changes()` even when
  they rewrite a row; the new test verifies effects by re-reading rows
  instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VP74zsfqS3CJKaEjNqwQB6
