### PR TITLE
fix: prevent stale compiled CTE root pages

### DIFF
--- a/crates/fsqlite-core/src/connection.rs
+++ b/crates/fsqlite-core/src/connection.rs
@@ -23967,13 +23967,15 @@ impl Connection {
         self.clear_compilation_reuse_caches();
     }
 
-    // DO NOT DELETE AS DEAD CODE -- this is a lost call site, not vestigial.
+    // DO NOT DELETE AS DEAD CODE -- this helper remains useful for synchronous
+    // scopes even though the asynchronous CTE materialization paths use
+    // `BoolCellRestoreGuard` directly across await points.
     //
     // `bypass_compiled_cache` is still *consumed* by `compile_with_cache`,
-    // which skips the compiled-program cache and recompiles when it is set.
-    // This helper is the only thing that can set it, and it currently has zero
-    // callers, so the bypass branch is unreachable in practice and the compiled
-    // cache is always consulted.
+    // which skips the compiled-program cache and recompiles when it is set. The
+    // CTE execution paths set it with an RAII guard so programs bound to
+    // dynamically allocated temp-table root pages are neither looked up nor
+    // inserted.
     //
     // That matters because CTE and view materialization allocate temp tables in
     // `MemDatabase` with *dynamic* root pages. A cached program compiled against
@@ -61396,6 +61398,7 @@ impl Connection {
         delete: &fsqlite_ast::DeleteStatement,
         params: Option<&[SqliteValue]>,
     ) -> Result<Vec<Row>> {
+        let _compiled_cache_guard = BoolCellRestoreGuard::new(&self.bypass_compiled_cache, true);
         if let Some(target_schema) = self.attached_target_schema(&delete.table.name)? {
             self.reject_attached_target_write_in_explicit_transaction(
                 "DELETE",
@@ -61439,7 +61442,6 @@ impl Connection {
             .await?;
         let mut stripped = delete.clone();
         stripped.with = None;
-        let _compiled_cache_guard = BoolCellRestoreGuard::new(&self.bypass_compiled_cache, true);
         self.execute_statement(&Statement::Delete(stripped), params)
             .await
     }
@@ -61451,6 +61453,7 @@ impl Connection {
         update: &fsqlite_ast::UpdateStatement,
         params: Option<&[SqliteValue]>,
     ) -> Result<Vec<Row>> {
+        let _compiled_cache_guard = BoolCellRestoreGuard::new(&self.bypass_compiled_cache, true);
         if let Some(target_schema) = self.attached_target_schema(&update.table.name)? {
             self.reject_attached_target_write_in_explicit_transaction(
                 "UPDATE",
@@ -61518,7 +61521,6 @@ impl Connection {
             .await?;
         let mut stripped = update.clone();
         stripped.with = None;
-        let _compiled_cache_guard = BoolCellRestoreGuard::new(&self.bypass_compiled_cache, true);
         self.execute_statement(&Statement::Update(stripped), params)
             .await
     }
@@ -61530,6 +61532,7 @@ impl Connection {
         insert: &fsqlite_ast::InsertStatement,
         params: Option<&[SqliteValue]>,
     ) -> Result<Vec<Row>> {
+        let _compiled_cache_guard = BoolCellRestoreGuard::new(&self.bypass_compiled_cache, true);
         if let Some(target_schema) = self.attached_target_schema(&insert.table)? {
             self.reject_attached_target_write_in_explicit_transaction(
                 "INSERT",
@@ -61611,8 +61614,6 @@ impl Connection {
             self.set_statement_change_count(outcome.changes);
             Ok(outcome.returning_rows)
         } else {
-            let _compiled_cache_guard =
-                BoolCellRestoreGuard::new(&self.bypass_compiled_cache, true);
             self.execute_statement(&Statement::Insert(stripped), params)
                 .await
         }

--- a/crates/fsqlite-core/tests/core_sql_rusqlite_conformance.rs
+++ b/crates/fsqlite-core/tests/core_sql_rusqlite_conformance.rs
@@ -3052,6 +3052,191 @@ fn cte_queries_match_rusqlite() {
 }
 
 #[test]
+fn repeated_cte_insert_select_matches_rusqlite() {
+    asupersync::test_utils::run_test(|| async {
+        let harness = CoreSqlConformanceHarness::new(
+            "CREATE TABLE cte_insert_target (
+                id INTEGER PRIMARY KEY,
+                value TEXT NOT NULL
+            );",
+        )
+        .await;
+        let statement = "
+            WITH incoming(value) AS (
+                SELECT 'alpha'
+                UNION ALL
+                SELECT 'beta'
+            )
+            INSERT INTO cte_insert_target(value)
+            SELECT value FROM incoming;
+        ";
+
+        harness.execute_script(statement).await;
+        harness.execute_script(statement).await;
+        harness
+            .assert_queries_match(
+                "repeated CTE INSERT SELECT",
+                &[QueryCase {
+                    name: "accumulated inserted rows",
+                    sql: "SELECT id, value FROM cte_insert_target ORDER BY id",
+                }],
+            )
+            .await;
+    });
+}
+
+#[test]
+fn repeated_nested_cte_insert_matches_rusqlite() {
+    asupersync::test_utils::run_test(|| async {
+        let harness = CoreSqlConformanceHarness::new(
+            "CREATE TABLE nested_cte_insert_target (
+                id INTEGER PRIMARY KEY,
+                value TEXT NOT NULL
+            );",
+        )
+        .await;
+        let statement = "
+            WITH base(value) AS (VALUES ('red'), ('blue')),
+                 nested(value) AS (SELECT value || '-x' FROM base)
+            INSERT INTO nested_cte_insert_target(value)
+            SELECT value FROM nested;
+        ";
+
+        harness.execute_script(statement).await;
+        harness.execute_script(statement).await;
+        harness
+            .assert_queries_match(
+                "repeated nested CTE INSERT",
+                &[QueryCase {
+                    name: "accumulated nested CTE rows",
+                    sql: "SELECT id, value FROM nested_cte_insert_target ORDER BY id",
+                }],
+            )
+            .await;
+    });
+}
+
+#[test]
+fn repeated_nested_cte_update_matches_rusqlite() {
+    asupersync::test_utils::run_test(|| async {
+        let harness = CoreSqlConformanceHarness::new(
+            "CREATE TABLE nested_cte_update_target (
+                id INTEGER PRIMARY KEY,
+                qty INTEGER NOT NULL
+            );
+            INSERT INTO nested_cte_update_target VALUES (1, 10), (2, 20);",
+        )
+        .await;
+        let statement = "
+            WITH base(id) AS (VALUES (1), (2)),
+                 nested(id) AS (SELECT id FROM base)
+            UPDATE nested_cte_update_target
+            SET qty = qty + 5
+            WHERE id IN (SELECT id FROM nested);
+        ";
+
+        harness.execute_script(statement).await;
+        harness.execute_script(statement).await;
+        harness
+            .assert_queries_match(
+                "repeated nested CTE UPDATE",
+                &[QueryCase {
+                    name: "twice updated rows",
+                    sql: "SELECT id, qty FROM nested_cte_update_target ORDER BY id",
+                }],
+            )
+            .await;
+    });
+}
+
+#[test]
+fn repeated_nested_cte_delete_matches_rusqlite() {
+    asupersync::test_utils::run_test(|| async {
+        let harness = CoreSqlConformanceHarness::new(
+            "CREATE TABLE nested_cte_delete_target (
+                id INTEGER PRIMARY KEY,
+                value TEXT NOT NULL
+            );
+            INSERT INTO nested_cte_delete_target VALUES
+                (1, 'a'), (2, 'b'), (3, 'c'),
+                (4, 'd'), (5, 'e'), (6, 'f');",
+        )
+        .await;
+        let statement = "
+            WITH base(id) AS (VALUES (2), (5)),
+                 nested(id) AS (SELECT id FROM base WHERE id > 0)
+            DELETE FROM nested_cte_delete_target
+            WHERE id IN (SELECT id FROM nested);
+        ";
+
+        harness.execute_script(statement).await;
+        harness.execute_script(statement).await;
+        harness
+            .assert_queries_match(
+                "repeated nested CTE DELETE",
+                &[QueryCase {
+                    name: "remaining rows after repeated delete",
+                    sql: "SELECT id, value FROM nested_cte_delete_target ORDER BY id",
+                }],
+            )
+            .await;
+    });
+}
+
+#[test]
+fn failed_cte_dml_restores_compiled_cache_eligibility() {
+    asupersync::test_utils::run_test(|| async {
+        let harness = CoreSqlConformanceHarness::new(
+            "CREATE TABLE cte_error_target (
+                id INTEGER PRIMARY KEY,
+                value TEXT NOT NULL UNIQUE
+            );
+            INSERT INTO cte_error_target VALUES (1, 'duplicate');",
+        )
+        .await;
+        let failing_statement = "
+            WITH base(value) AS (VALUES ('duplicate')),
+                 nested(value) AS (SELECT value FROM base)
+            INSERT INTO cte_error_target(value)
+            SELECT value FROM nested;
+        ";
+
+        for _ in 0..2 {
+            let franken_error = harness
+                .franken
+                .execute_batch(failing_statement)
+                .await
+                .is_err();
+            let sqlite_error = harness.sqlite.execute_batch(failing_statement).is_err();
+            assert!(
+                sqlite_error,
+                "rusqlite should reject the duplicate CTE insert"
+            );
+            assert_eq!(
+                franken_error, sqlite_error,
+                "failed repeated CTE DML should match rusqlite"
+            );
+        }
+
+        harness.franken.clear_compilation_reuse_caches();
+        let cache_probe = [QueryCase {
+            name: "ordinary SELECT after failed CTE DML",
+            sql: "SELECT value FROM cte_error_target WHERE id = 1",
+        }];
+        harness
+            .assert_queries_match("post-error cache restoration", &cache_probe)
+            .await;
+        harness
+            .assert_queries_match("post-error cache restoration", &cache_probe)
+            .await;
+        assert!(
+            harness.franken.compiled_cache_len() > 0,
+            "ordinary statements should remain eligible for compiled caching"
+        );
+    });
+}
+
+#[test]
 fn values_clause_edges_match_rusqlite() {
     asupersync::test_utils::run_test(|| async {
         let harness = CoreSqlConformanceHarness::new(SUBQUERY_SETUP).await;


### PR DESCRIPTION
Install `BoolCellRestoreGuard` at the start of each CTE DML entry point—`execute_insert_with_ctes`, `execute_update_with_ctes`, and `execute_delete_with_ctes`—so the bypass covers CTE materialization or attached-schema snapshotting and the complete stripped-statement execution. Remove the narrower downstream guards made redundant by that outer lifetime, retain the child-connection guard in `execute_statement_with_materialized_temp_tables` because it protects a different connection during attached-schema execution, and reconcile the obsolete dead-helper comment with the now-reachable RAII path. This avoids both cache lookup and insertion for programs bound to ephemeral root pages without clearing unrelated compiled or prepared entries, and the RAII guard restores the prior flag on success, error, or cancellation.

Repeated CTE-driven DML can reuse compiled bytecode that embeds a temporary table root page destroyed after the preceding statement. The defect remains on current `main`: `execute_insert_with_ctes` runs the SELECT source without `bypass_compiled_cache`, while `materialize_with_clause` executes non-recursive CTE bodies before the narrower DELETE, UPDATE, and non-SELECT INSERT guards are installed. A second identical statement can therefore hit the canonical-SQL compiled cache after the CTE has been rematerialized at another root page. There are no competing or prior closed-unmerged PRs, and the repository already contains the RAII guard and SQLite-oracle test infrastructure needed for a focused fix.

Happy path: execute the identical `WITH ... INSERT INTO ... SELECT ...` statement twice on the same FrankenSQLite and rusqlite connections, then assert both engines return the same accumulated target rows; Edge cases: repeat nested CTE chains where a later CTE reads an earlier materialized CTE through INSERT, UPDATE, and DELETE lanes, and compare final ordered rows with rusqlite after each two-execution sequence.

Fixes #255

AI was used for assistance.
