### PR TITLE
fix(install): pin docs to explicit v0.1.17 while latest is legacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ The current runnable engine is already real, but still hybrid. Compatibility mod
 Linux and macOS:
 
 ```bash
-curl -fsSL "https://raw.githubusercontent.com/Dicklesworthstone/frankensqlite/main/install.sh?$(date +%s)" | bash
+curl -fsSL "https://raw.githubusercontent.com/Dicklesworthstone/frankensqlite/main/install.sh?$(date +%s)" | bash -s -- --version v0.1.17
 ```
 
 Windows PowerShell:
 
 ```powershell
-irm "https://raw.githubusercontent.com/Dicklesworthstone/frankensqlite/main/install.ps1?$([DateTime]::UtcNow.Ticks)" | iex
+& ([scriptblock]::Create((irm "https://raw.githubusercontent.com/Dicklesworthstone/frankensqlite/main/install.ps1?$([DateTime]::UtcNow.Ticks)"))) -Version v0.1.17
 ```
 
 The installers select the native release artifact, require its SHA-256 entry,
@@ -52,8 +52,11 @@ post-install verification controls are documented by `install.sh --help` and
 `Get-Help ./install.ps1 -Detailed`. Rust users can instead install the CLI with
 `cargo install fsqlite-cli --locked`. Prebuilt installer support covers
 v0.1.16-v0.1.17 and resumes with v0.2.0; v0.1.18-v0.1.19 did not publish native
-signed artifact sets. When `minisign` is present, a missing or invalid
-signature fails closed rather than silently downgrading authenticity.
+signed artifact sets. GitHub `latest` is still the epoch-1 release `v0.1.17`,
+so the installers require an explicit version rather than auto-resolving that
+legacy signing epoch; drop `--version` / `-Version` once a non-legacy latest
+(such as `v0.2.0`) is published. When `minisign` is present, a missing or
+invalid signature fails closed rather than silently downgrading authenticity.
 
 ### Why FrankenSQLite?
 

--- a/install.ps1
+++ b/install.ps1
@@ -40,9 +40,11 @@ HTTP or HTTPS proxy URI. Defaults to HTTPS_PROXY, then HTTP_PROXY.
 Preserve the unique temporary directory for diagnostics.
 
 .EXAMPLE
-irm "https://raw.githubusercontent.com/Dicklesworthstone/frankensqlite/main/install.ps1?$([DateTime]::UtcNow.Ticks)" | iex
+& ([scriptblock]::Create((irm "https://raw.githubusercontent.com/Dicklesworthstone/frankensqlite/main/install.ps1?$([DateTime]::UtcNow.Ticks)"))) -Version v0.1.17
 
-Installs the latest release with a cache-busting request.
+Installs the current published release with a cache-busting request. GitHub
+latest is still epoch-1 v0.1.17, so -Version must be explicit until a
+non-legacy latest ships.
 
 .EXAMPLE
 .\install.ps1 -Version v0.2.0 -Destination C:\Tools\FrankenSQLite

--- a/install.sh
+++ b/install.sh
@@ -2,10 +2,12 @@
 #
 # FrankenSQLite installer
 #
-# One-line install (cache-busting query avoids stale proxy/CDN copies):
-#   curl -fsSL "https://raw.githubusercontent.com/Dicklesworthstone/frankensqlite/main/install.sh?$(date +%s)" | bash
+# One-line install (cache-busting query avoids stale proxy/CDN copies).
+# GitHub latest is still epoch-1 v0.1.17, so pass --version explicitly:
+#   curl -fsSL "https://raw.githubusercontent.com/Dicklesworthstone/frankensqlite/main/install.sh?$(date +%s)" | bash -s -- --version v0.1.17
 #
 # Examples:
+#   bash install.sh --version v0.1.17
 #   bash install.sh --version v0.2.0
 #   bash install.sh --offline ./fsqlite-0.2.0-linux_amd64.tar.gz --checksum SHA256
 #


### PR DESCRIPTION
## Summary

- Fixes the broken advertised install path while GitHub `latest` remains epoch-1 `v0.1.17`.
- Updates README Linux/macOS and Windows install snippets to require an explicit version.
- Aligns `install.sh` / `install.ps1` header examples with the same guidance.

Closes #330

## Test plan

- [ ] Confirm GitHub `releases/latest` is still `v0.1.17`
- [ ] Confirm unversioned installer resolution still errors with the legacy message
- [ ] Confirm `install.sh --version v0.1.17` installs successfully
- [ ] Confirm README / installer header snippets match the working invocation
