### PR TITLE
fix(core): keep schema-only prepared reads pager-backed

### DIFF
--- a/crates/fsqlite-core/src/connection.rs
+++ b/crates/fsqlite-core/src/connection.rs
@@ -12062,6 +12062,14 @@ pub struct Connection {
     /// fallback and require all cursor operations to route through the real
     /// Pager+BtreeCursor stack. Used for parity-certification testing.
     reject_mem_fallback: RefCell<bool>,
+    /// Keep file-backed row data pager-resident even when a prepared-query
+    /// shape has an optional MemDatabase fast path.
+    ///
+    /// The schema-only open family promises bounded-memory, pager-backed
+    /// reads. Without this mode bit, its first parameterized indexed lookup
+    /// can opportunistically hydrate every table merely to enter a MemDB fast
+    /// path, defeating that contract on large databases.
+    defer_memdb_row_hydration: bool,
     /// Whether schema reload may keep a contentless FTS5 table in the
     /// bounded, on-disk lazy representation.
     ///
@@ -13129,6 +13137,27 @@ impl Connection {
         Self::open_existing_schema_only_with_env(path, ConnectionEnv::default()).await
     }
 
+    /// Open an existing database through a read-only schema connection while
+    /// deferring FTS5 shadow validation and hydration.
+    ///
+    /// This is for canonical-data consumers that do not query FTS5 tables.
+    /// Ordinary tables remain available through pager-backed cursors, while
+    /// FTS5 virtual tables stay as empty connected instances for the lifetime
+    /// of the connection. Writes are refused by the read-only pager.
+    pub async fn open_schema_only_deferred_fts5(path: impl Into<String>) -> Result<Self> {
+        Self::open_schema_only_deferred_fts5_with_env(path, ConnectionEnv::default()).await
+    }
+
+    /// [`open_schema_only_deferred_fts5`](Self::open_schema_only_deferred_fts5)
+    /// with an explicit runtime environment.
+    pub async fn open_schema_only_deferred_fts5_with_env(
+        path: impl Into<String>,
+        env: ConnectionEnv,
+    ) -> Result<Self> {
+        Self::open_schema_only_with_optional_expected_identity_and_env(path, None, env, false, true)
+            .await
+    }
+
     /// #368 defect 3: like [`open_existing_schema_only`](Self::open_existing_schema_only)
     /// but DEFERS FTS5 shadow validation/hydration at open. The schema reload
     /// keeps bare, empty FTS5 vtab instances and never reads/validates `%_data`,
@@ -13561,6 +13590,7 @@ impl Connection {
             // Schema-only connections always use parity-cert mode (pager-backed
             // cursors); the MemDatabase is deliberately left empty.
             reject_mem_fallback: RefCell::new(true),
+            defer_memdb_row_hydration: true,
             allow_lazy_contentless_fts5: true,
             defer_fts5_hydration,
             skip_statement_memdb_refresh: Cell::new(false),
@@ -14094,6 +14124,7 @@ impl Connection {
             // via `set_reject_mem_fallback(false)` or
             // `PRAGMA fsqlite.parity_cert = OFF`.
             reject_mem_fallback: RefCell::new(true),
+            defer_memdb_row_hydration: false,
             allow_lazy_contentless_fts5: false,
             defer_fts5_hydration: false,
             skip_statement_memdb_refresh: Cell::new(false),
@@ -26878,6 +26909,14 @@ impl Connection {
             && self.retained_autocommit_txn.borrow().is_none()
             && self.pending_memdb_direct_upserts.borrow().is_empty()
             && !self.memdb_requires_active_txn_reload.get()
+            && self.prepared_file_backed_memdb_hydration_allowed(stmt)
+    }
+
+    fn prepared_file_backed_memdb_hydration_allowed(
+        &self,
+        stmt: &PreparedStatement<'_>,
+    ) -> bool {
+        !self.defer_memdb_row_hydration
             && stmt
                 .prepared_query_fast_path
                 .as_ref()
@@ -54811,10 +54850,8 @@ impl Connection {
         }
 
         if self.committed_pager_refresh_allowed() {
-            let hydrate_file_backed_fast_path = stmt
-                .prepared_query_fast_path
-                .as_ref()
-                .is_some_and(PreparedQueryFastPath::can_use_clean_file_backed_memdb);
+            let hydrate_file_backed_fast_path =
+                self.prepared_file_backed_memdb_hydration_allowed(stmt);
             if hydrate_file_backed_fast_path {
                 let _ = self
                     .refresh_memdb_if_stale_with_publication_and_mode(

--- a/crates/fsqlite/src/async_api.rs
+++ b/crates/fsqlite/src/async_api.rs
@@ -1710,6 +1710,9 @@ enum WorkerOpenRequest {
     SchemaOnly {
         path: String,
     },
+    SchemaOnlyDeferredFts5 {
+        path: String,
+    },
     WithFlags {
         path: String,
         flags: OpenFlags,
@@ -1736,6 +1739,9 @@ impl WorkerOpenRequest {
             } => Connection::open_with_page_size(path, page_size_bytes).await,
             Self::Existing { path } => Connection::open_existing(path).await,
             Self::SchemaOnly { path } => Connection::open_schema_only(path).await,
+            Self::SchemaOnlyDeferredFts5 { path } => {
+                Connection::open_schema_only_deferred_fts5(path).await
+            }
             Self::WithFlags { path, flags } => open_with_flags(&path, flags).await,
             Self::ReservedWithExpectedIdentityAndEnv {
                 path,
@@ -2024,6 +2030,18 @@ impl AsyncConnection {
     /// avoid introducing writer semantics such as close-time checkpoints.
     pub fn open_schema_only_sync(path: impl Into<String>) -> Result<Self, FrankenError> {
         Self::open_sync_with_request(WorkerOpenRequest::SchemaOnly { path: path.into() })
+    }
+
+    /// Open an existing database on a dedicated worker through the read-only,
+    /// schema-only connection that deliberately leaves FTS5 unhydrated.
+    ///
+    /// Canonical non-FTS tables remain queryable and every write is refused.
+    pub fn open_schema_only_deferred_fts5_sync(
+        path: impl Into<String>,
+    ) -> Result<Self, FrankenError> {
+        Self::open_sync_with_request(WorkerOpenRequest::SchemaOnlyDeferredFts5 {
+            path: path.into(),
+        })
     }
 
     /// Open a database with explicit SQLite-compatible [`OpenFlags`].
@@ -6561,6 +6579,25 @@ mod tests {
             Some(&SqliteValue::Text("t".into())),
             "schema-only mode must expose the persisted table definition"
         );
+        conn.close_sync().expect("close should succeed");
+    }
+
+    #[cfg(all(feature = "native", any(unix, windows)))]
+    #[test]
+    fn open_schema_only_deferred_fts5_sync_reads_canonical_data_and_refuses_writes() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let path = seeded_database(&dir, "schema-only-deferred-fts5.db");
+        let mut conn = AsyncConnection::open_schema_only_deferred_fts5_sync(&path)
+            .expect("deferred-fts5 schema-only open should succeed");
+        let rows = conn
+            .query_sync("SELECT name FROM t WHERE id = 1")
+            .expect("canonical row should remain readable");
+        assert_eq!(
+            rows.first().and_then(|row| row.get(0)),
+            Some(&SqliteValue::Text("seeded".into()))
+        );
+        conn.execute_sync("INSERT INTO t VALUES (2, 'refused')")
+            .expect_err("deferred-fts5 schema-only open must refuse writes");
         conn.close_sync().expect("close should succeed");
     }
 

--- a/crates/fsqlite/tests/fts5_deferred_open_cass368.rs
+++ b/crates/fsqlite/tests/fts5_deferred_open_cass368.rs
@@ -25,6 +25,12 @@ fn deferred_fts5_open_survives_corrupt_shadow_structure() {
         {
             let conn = Connection::open(&path).await.unwrap();
             conn.execute("PRAGMA journal_mode = WAL;").await.unwrap();
+            conn.execute("CREATE TABLE canonical_meta(key TEXT PRIMARY KEY, value TEXT NOT NULL)")
+                .await
+                .expect("create canonical table");
+            conn.execute("INSERT INTO canonical_meta VALUES ('semantic_state', 'kept')")
+                .await
+                .expect("seed canonical row");
             conn.execute("CREATE VIRTUAL TABLE idx USING fts5(body, content='')")
                 .await
                 .expect("create contentless fts5");
@@ -65,6 +71,42 @@ fn deferred_fts5_open_survives_corrupt_shadow_structure() {
                 || message.contains("segment"),
             "expected an FTS5 %_data corruption error, got: {message}"
         );
+
+        // Canonical-data consumers need the same deferred hydration without a
+        // writable handle. Ordinary tables remain readable, while the pager
+        // refuses mutations for the full lifetime of the connection.
+        let readonly = Connection::open_schema_only_deferred_fts5(&path)
+            .await
+            .expect("read-only deferred-fts5 open must ignore the corrupt shadow");
+        assert_eq!(
+            readonly.memdb_row_hydration_count(),
+            0,
+            "schema-only open must not hydrate canonical rows into MemDatabase"
+        );
+        let canonical = readonly
+            .query_row_with_params(
+                "SELECT value FROM canonical_meta WHERE key = ?1",
+                &[SqliteValue::Text("semantic_state".into())],
+            )
+            .await
+            .expect("canonical table remains readable");
+        assert_eq!(
+            canonical.values().first(),
+            Some(&SqliteValue::Text("kept".into()))
+        );
+        assert_eq!(
+            readonly.memdb_row_hydration_count(),
+            0,
+            "prepared canonical lookup must remain pager-backed"
+        );
+        readonly
+            .execute("INSERT INTO canonical_meta VALUES ('refused', 'refused')")
+            .await
+            .expect_err("read-only deferred-fts5 open must refuse writes");
+        readonly
+            .close_without_checkpoint()
+            .await
+            .expect("close read-only deferred-fts5 connection");
 
         // The deferred-hydration repair open must SUCCEED: it keeps the bare FTS5
         // vtab and never reads %_data (#368 defect 3), so a repair path can now


### PR DESCRIPTION
## Summary

- add a read-only schema-only open mode that deliberately leaves FTS5 unhydrated
- keep prepared ordinary-table reads pager-backed for schema-only connections
- expose the same mode through `AsyncConnection`
- add a regression proving a parameterized canonical lookup does not hydrate the in-memory database and that writes remain refused

## Problem

The schema-only open family promises bounded-memory, pager-backed reads. A prepared indexed query can currently pass through:

`prepare_clean_file_backed_prepared_memdb_fast_path -> refresh_memdb_if_stale -> reload_memdb_from_pager`

That opportunistic fast path hydrates all file-backed rows into `MemDatabase`. On a large archive, the first small parameterized lookup can therefore consume memory proportional to the entire database.

The adjacent deferred-FTS5 repair API is writable. A downstream canonical-data reader needs the same deferred FTS5 behavior on a handle that cannot mutate the archive.

## Approach

This change gives schema-only connections an explicit `defer_memdb_row_hydration` invariant and applies it at both gates for the optional prepared-query MemDB fast path. Ordinary connection modes retain their existing behavior.

`Connection::open_schema_only_deferred_fts5` and its async wrapper combine:

- a read-only pager
- pager-backed ordinary-table reads
- deferred FTS5 shadow validation/hydration

## Verification

On current `main`, the synthetic regression failed after the parameterized lookup with six hydrated rows instead of zero. With this branch:

```text
cargo test -p fsqlite --features fts5 --test fts5_deferred_open_cass368
1 passed

cargo test -p fsqlite --features fts5,async-api --lib \
  open_schema_only_deferred_fts5_sync_reads_canonical_data_and_refuses_writes
1 passed

cargo fmt --all -- --check
git diff --check
```

In an out-of-tree downstream check against a multi-gigabyte archive, representative canonical reads stayed around 1.3-2.2 GB RSS and completed in roughly 2.6-5.1 seconds. The previous path reached roughly 8.7 GB RSS and took 8.6-13.3 seconds or failed to complete. No downstream data, paths, or query content are included here.

## Scope

The new behavior is opt-in through the schema-only family. Normal opens and their prepared-query fast paths are unchanged. The tests also prove that the new public open mode reads an ordinary canonical table, survives an unusable FTS5 shadow, remains pager-backed, and refuses writes.

This is submitted as a narrow reference implementation; a maintainer rewrite that preserves those invariants is entirely welcome.
